### PR TITLE
Fix Gemini API key handling issues

### DIFF
--- a/tests/test_ai_agent_ha/test_agent_clients.py
+++ b/tests/test_ai_agent_ha/test_agent_clients.py
@@ -125,9 +125,9 @@ class TestGeminiClient:
         try:
             from custom_components.ai_agent_ha.agent import GeminiClient
             
-            client = GeminiClient("test-token", "gemini-1.5-flash")
+            client = GeminiClient("test-token", "gemini-2.5-flash")
             assert client.token == "test-token"
-            assert client.model == "gemini-1.5-flash"
+            assert client.model == "gemini-2.5-flash"
         except ImportError:
             pytest.skip("GeminiClient not available")
 


### PR DESCRIPTION
## Summary
Fixes API key validation errors with Gemini provider by properly handling whitespace and special characters in API keys.

## Problem
Users were experiencing "API key not valid" errors (400 status) even with valid Gemini API keys because:
1. API keys with leading/trailing whitespace weren't being trimmed
2. Special characters in API keys weren't being URL-encoded in the query parameter

## Changes Made
- ✅ Strip whitespace from API tokens: `self.token = token.strip() if token else token`
- ✅ Add URL encoding for API key in query parameter: `quote(self.token)`
- ✅ Update fallback model reference from gemini-1.5-flash to gemini-2.5-flash in agent initialization
- ✅ Update docstring examples to show current model names
- ✅ Update test cases to use gemini-2.5-flash

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
### How to Test
1. Copy a Gemini API key with extra whitespace (common when copying from web)
2. Configure the Gemini provider in Home Assistant
3. Send a test query - should now work without "API key not valid" errors

### Test Cases
- [ ] API key with leading whitespace
- [ ] API key with trailing whitespace
- [ ] API key with special characters that need URL encoding
- [ ] Standard API key (ensure no regression)

## Related Issues
Addresses API key validation errors reported after #25 was fixed.
Follows up on #28.

## Checklist
- [x] Code follows project's coding standards
- [x] Passes flake8 linting
- [x] Passes mypy type checking
- [x] Updated test cases
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)