### PR TITLE
feat: add OpenAI-compatible local model support (LM Studio, vLLM) and fix 5-minute UI timeout

### DIFF
--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -117,12 +117,29 @@ class LocalClient(BaseAIClient):
     def __init__(self, url, model=""):
         self.url = url
         self.model = model
+        # Detect OpenAI-compatible endpoints (e.g. LM Studio, vLLM, LocalAI)
+        # by checking if the URL contains '/v1'. If so, use the OpenAI chat
+        # completions format instead of the Ollama-native prompt format.
+        self._is_openai_compatible = "/v1" in (url or "")
+        if self._is_openai_compatible:
+            # Ensure the request URL targets /v1/chat/completions
+            self._chat_url = url.rstrip("/")
+            if not self._chat_url.endswith("/chat/completions"):
+                if self._chat_url.endswith("/v1"):
+                    self._chat_url += "/chat/completions"
+                else:
+                    self._chat_url += "/v1/chat/completions"
+            _LOGGER.info(
+                "Detected OpenAI-compatible local endpoint. Chat URL: %s",
+                self._chat_url,
+            )
 
     async def get_response(self, messages, **kwargs):
         _LOGGER.debug(
-            "Making request to local API with model: '%s' at URL: %s",
+            "Making request to local API with model: '%s' at URL: %s (openai_compat=%s)",
             self.model or "[NO MODEL SPECIFIED]",
             self.url,
+            self._is_openai_compatible,
         )
 
         if not self.model:
@@ -131,51 +148,65 @@ class LocalClient(BaseAIClient):
             )
         headers = {"Content-Type": "application/json"}
 
-        # Format user prompt from messages
-        prompt = ""
-        for message in messages:
-            role = message.get("role", "")
-            content = message.get("content", "")
+        # Choose request format based on detected endpoint type
+        if self._is_openai_compatible:
+            # OpenAI-compatible format (LM Studio, vLLM, LocalAI, etc.)
+            # Send structured messages array to /v1/chat/completions
+            payload = {
+                "messages": messages,
+                "stream": False,
+                "temperature": 0.7,
+                "top_p": 0.9,
+            }
+            if self.model:
+                payload["model"] = self.model
+            request_url = self._chat_url
+            _LOGGER.debug(
+                "Using OpenAI-compatible format → POST %s", request_url
+            )
+        else:
+            # Legacy Ollama-native format: flatten messages into a prompt string
+            prompt = ""
+            for message in messages:
+                role = message.get("role", "")
+                content = message.get("content", "")
+                if role == "system":
+                    prompt += f"System: {content}\n\n"
+                elif role == "user":
+                    prompt += f"User: {content}\n\n"
+                elif role == "assistant":
+                    prompt += f"Assistant: {content}\n\n"
+            prompt += "Assistant: "
 
-            # Simple formatting: prefixing each message with its role
-            if role == "system":
-                prompt += f"System: {content}\n\n"
-            elif role == "user":
-                prompt += f"User: {content}\n\n"
-            elif role == "assistant":
-                prompt += f"Assistant: {content}\n\n"
-
-        # Add final prompt prefix for the assistant's response
-        prompt += "Assistant: "
-
-        # Build a generic payload that works with most local API servers
-        payload = {
-            "prompt": prompt,
-            "stream": False,  # Disable streaming to get a single complete response
-            # max_tokens omitted - let local model use its default capacity
-        }
-
-        # Add model if specified
-        if self.model:
-            payload["model"] = self.model
+            payload = {
+                "prompt": prompt,
+                "stream": False,
+            }
+            if self.model:
+                payload["model"] = self.model
+            request_url = self.url
+            _LOGGER.debug(
+                "Using Ollama-native format → POST %s", request_url
+            )
 
         # Note: Payloads don't contain auth tokens (those are in headers), but may contain user prompts
         _LOGGER.debug("Local API request payload: %s", json.dumps(payload, indent=2))
 
-        # Ollama-specific validation
-        if "model" not in payload or not payload["model"]:
-            _LOGGER.warning(
-                "Missing 'model' field in request to local API. This may cause issues with Ollama."
-            )
-        elif self.url and "ollama" in self.url.lower():
-            _LOGGER.debug(
-                "Detected Ollama URL, ensuring model is specified: %s",
-                payload.get("model"),
-            )
+        # Ollama-specific validation (only for non-OpenAI-compatible endpoints)
+        if not self._is_openai_compatible:
+            if "model" not in payload or not payload["model"]:
+                _LOGGER.warning(
+                    "Missing 'model' field in request to local API. This may cause issues with Ollama."
+                )
+            elif self.url and "ollama" in self.url.lower():
+                _LOGGER.debug(
+                    "Detected Ollama URL, ensuring model is specified: %s",
+                    payload.get("model"),
+                )
 
         async with aiohttp.ClientSession() as session:
             async with session.post(
-                self.url,
+                request_url,
                 headers=headers,
                 json=payload,
                 timeout=aiohttp.ClientTimeout(total=300),
@@ -486,10 +517,21 @@ class LlamaClient(BaseAIClient):
 
 
 class OpenAIClient(BaseAIClient):
-    def __init__(self, token, model="gpt-3.5-turbo"):
+    def __init__(self, token, model="gpt-3.5-turbo", base_url=""):
         self.token = token
         self.model = model
-        self.api_url = "https://api.openai.com/v1/chat/completions"
+        # Use custom base URL if provided (e.g. LM Studio at http://192.168.0.57:1234/v1)
+        if base_url and base_url.strip():
+            self.api_url = base_url.rstrip("/") + "/chat/completions"
+            self._custom_endpoint = True
+            _LOGGER.info(
+                "OpenAIClient using custom endpoint: %s (model: %s)",
+                self.api_url,
+                self.model,
+            )
+        else:
+            self.api_url = "https://api.openai.com/v1/chat/completions"
+            self._custom_endpoint = False
 
     def _is_restricted_model(self):
         """Check if the model has restricted parameters (no temperature, top_p, etc.)."""
@@ -502,8 +544,10 @@ class OpenAIClient(BaseAIClient):
     async def get_response(self, messages, **kwargs):
         _LOGGER.debug("Making request to OpenAI API with model: %s", self.model)
 
-        # Validate token
-        if not self.token or not self.token.startswith("sk-"):
+        # Validate token — skip sk- prefix check for custom endpoints (e.g. LM Studio)
+        if not self.token:
+            raise Exception("Invalid OpenAI API key format")
+        if not self._custom_endpoint and not self.token.startswith("sk-"):
             raise Exception("Invalid OpenAI API key format")
 
         headers = {
@@ -1170,7 +1214,8 @@ class AiAgentHaAgent:
         # Initialize the appropriate AI client with model selection
         if provider == "openai":
             model = models_config.get("openai", "gpt-3.5-turbo")
-            self.ai_client = OpenAIClient(config.get("openai_token"), model)
+            base_url = config.get("openai_base_url", "") or ""
+            self.ai_client = OpenAIClient(config.get("openai_token"), model, base_url)
         elif provider == "gemini":
             model = models_config.get("gemini", "gemini-2.5-flash")
             self.ai_client = GeminiClient(config.get("gemini_token"), model)
@@ -1231,6 +1276,10 @@ class AiAgentHaAgent:
         # For local provider, validate URL format
         if provider == "local":
             return bool(token.startswith(("http://", "https://")))
+
+        # For OpenAI with a custom base URL (e.g. LM Studio), skip the length check
+        if provider == "openai" and self.config.get("openai_base_url", "").strip():
+            return len(token) > 0
 
         # Add more specific validation based on your API key format
         return len(token) >= 32
@@ -2693,9 +2742,16 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                     )
                 else:
                     # Other clients take (token, model)
-                    self.ai_client = provider_settings["client_class"](
-                        token=token, model=provider_settings["model"]
-                    )
+                    # For OpenAI, also pass optional custom base_url override
+                    if selected_provider == "openai":
+                        base_url = config.get("openai_base_url", "") or ""
+                        self.ai_client = provider_settings["client_class"](
+                            token=token, model=provider_settings["model"], base_url=base_url
+                        )
+                    else:
+                        self.ai_client = provider_settings["client_class"](
+                            token=token, model=provider_settings["model"]
+                        )
                     _LOGGER.debug(
                         f"Initialized {selected_provider} client with model {provider_settings['model']}"
                     )

--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -161,9 +161,7 @@ class LocalClient(BaseAIClient):
             if self.model:
                 payload["model"] = self.model
             request_url = self._chat_url
-            _LOGGER.debug(
-                "Using OpenAI-compatible format → POST %s", request_url
-            )
+            _LOGGER.debug("Using OpenAI-compatible format → POST %s", request_url)
         else:
             # Legacy Ollama-native format: flatten messages into a prompt string
             prompt = ""
@@ -185,9 +183,7 @@ class LocalClient(BaseAIClient):
             if self.model:
                 payload["model"] = self.model
             request_url = self.url
-            _LOGGER.debug(
-                "Using Ollama-native format → POST %s", request_url
-            )
+            _LOGGER.debug("Using Ollama-native format → POST %s", request_url)
 
         # Note: Payloads don't contain auth tokens (those are in headers), but may contain user prompts
         _LOGGER.debug("Local API request payload: %s", json.dumps(payload, indent=2))
@@ -2746,7 +2742,9 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                     if selected_provider == "openai":
                         base_url = config.get("openai_base_url", "") or ""
                         self.ai_client = provider_settings["client_class"](
-                            token=token, model=provider_settings["model"], base_url=base_url
+                            token=token,
+                            model=provider_settings["model"],
+                            base_url=base_url,
                         )
                     else:
                         self.ai_client = provider_settings["client_class"](

--- a/custom_components/ai_agent_ha/config_flow.py
+++ b/custom_components/ai_agent_ha/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.selector import (
     TextSelectorConfig,
 )
 
-from .const import CONF_LOCAL_MODEL, CONF_LOCAL_URL, DOMAIN
+from .const import CONF_LOCAL_MODEL, CONF_LOCAL_URL, CONF_OPENAI_BASE_URL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,6 +41,8 @@ TOKEN_FIELD_NAMES = {
     "zai_endpoint": "zai_endpoint",
     "local": CONF_LOCAL_URL,  # For local models, we use URL instead of token
 }
+
+OPENAI_BASE_URL_LABEL = "Custom Base URL (optional, e.g. http://192.168.0.57:1234/v1 for LM Studio)"
 
 TOKEN_LABELS = {
     "llama": "Llama API Token",
@@ -218,6 +220,11 @@ class AiAgentHaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
                 # Store the configuration data
                 self.config_data[token_field] = token_value
 
+                # For OpenAI, persist optional custom base URL
+                if provider == "openai":
+                    base_url = user_input.get(CONF_OPENAI_BASE_URL, "").strip()
+                    self.config_data[CONF_OPENAI_BASE_URL] = base_url
+
                 # For z.ai, store endpoint type
                 if provider == "zai":
                     endpoint_type = user_input.get("zai_endpoint", "general")
@@ -326,6 +333,12 @@ class AiAgentHaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
             ),
         }
 
+        # For OpenAI provider, add optional custom base URL override
+        if provider == "openai":
+            schema_dict[vol.Optional(CONF_OPENAI_BASE_URL, default="")] = TextSelector(
+                TextSelectorConfig(type="url")
+            )
+
         # Add model selection if available
         if available_models:
             # Add predefined models + custom option (avoid duplicating "Custom...")
@@ -422,6 +435,11 @@ class AiAgentHaOptionsFlowHandler(config_entries.OptionsFlow):
                     updated_data = dict(self.config_entry.data)
                     updated_data["ai_provider"] = provider
                     updated_data[token_field] = token_value
+
+                    # For OpenAI, persist custom base URL if provided
+                    if provider == "openai":
+                        base_url = user_input.get(CONF_OPENAI_BASE_URL, "").strip()
+                        updated_data[CONF_OPENAI_BASE_URL] = base_url
 
                     # Update model configuration
                     selected_model = user_input.get("model")
@@ -538,6 +556,13 @@ class AiAgentHaOptionsFlowHandler(config_entries.OptionsFlow):
                 TextSelectorConfig(type="password")
             ),
         }
+
+        # For OpenAI provider, add optional custom base URL override
+        if provider == "openai":
+            current_base_url = self.config_entry.data.get(CONF_OPENAI_BASE_URL, "")
+            schema_dict[vol.Optional(CONF_OPENAI_BASE_URL, default=current_base_url)] = TextSelector(
+                TextSelectorConfig(type="url")
+            )
 
         # Add model selection if available
         if available_models:

--- a/custom_components/ai_agent_ha/config_flow.py
+++ b/custom_components/ai_agent_ha/config_flow.py
@@ -42,7 +42,9 @@ TOKEN_FIELD_NAMES = {
     "local": CONF_LOCAL_URL,  # For local models, we use URL instead of token
 }
 
-OPENAI_BASE_URL_LABEL = "Custom Base URL (optional, e.g. http://192.168.0.57:1234/v1 for LM Studio)"
+OPENAI_BASE_URL_LABEL = (
+    "Custom Base URL (optional, e.g. http://192.168.0.57:1234/v1 for LM Studio)"
+)
 
 TOKEN_LABELS = {
     "llama": "Llama API Token",
@@ -560,9 +562,9 @@ class AiAgentHaOptionsFlowHandler(config_entries.OptionsFlow):
         # For OpenAI provider, add optional custom base URL override
         if provider == "openai":
             current_base_url = self.config_entry.data.get(CONF_OPENAI_BASE_URL, "")
-            schema_dict[vol.Optional(CONF_OPENAI_BASE_URL, default=current_base_url)] = TextSelector(
-                TextSelectorConfig(type="url")
-            )
+            schema_dict[
+                vol.Optional(CONF_OPENAI_BASE_URL, default=current_base_url)
+            ] = TextSelector(TextSelectorConfig(type="url"))
 
         # Add model selection if available
         if available_models:

--- a/custom_components/ai_agent_ha/const.py
+++ b/custom_components/ai_agent_ha/const.py
@@ -14,7 +14,9 @@ CONF_ALTER_TOKEN = "alter_token"  # nosec B105
 CONF_ZAI_TOKEN = "zai_token"  # nosec B105
 CONF_LOCAL_URL = "local_url"
 CONF_LOCAL_MODEL = "local_model"
-CONF_OPENAI_BASE_URL = "openai_base_url"  # Optional custom endpoint for OpenAI-compatible servers
+CONF_OPENAI_BASE_URL = (
+    "openai_base_url"  # Optional custom endpoint for OpenAI-compatible servers
+)
 
 # Available AI providers
 AI_PROVIDERS = [

--- a/custom_components/ai_agent_ha/const.py
+++ b/custom_components/ai_agent_ha/const.py
@@ -14,6 +14,7 @@ CONF_ALTER_TOKEN = "alter_token"  # nosec B105
 CONF_ZAI_TOKEN = "zai_token"  # nosec B105
 CONF_LOCAL_URL = "local_url"
 CONF_LOCAL_MODEL = "local_model"
+CONF_OPENAI_BASE_URL = "openai_base_url"  # Optional custom endpoint for OpenAI-compatible servers
 
 # Available AI providers
 AI_PROVIDERS = [

--- a/custom_components/ai_agent_ha/frontend/ai_agent_ha-panel.js
+++ b/custom_components/ai_agent_ha/frontend/ai_agent_ha-panel.js
@@ -1143,7 +1143,9 @@ class AiAgentHaPanel extends LitElement {
       clearTimeout(this._serviceCallTimeout);
     }
 
-    // Set timeout to clear loading state after 60 seconds
+    // Set timeout to clear loading state after 300 seconds
+    // Increased from 60s to support local models (LM Studio, Ollama) which
+    // may take longer to generate responses on local hardware.
     this._serviceCallTimeout = setTimeout(() => {
       if (this._isLoading) {
         console.warn("Service call timeout - clearing loading state");
@@ -1155,7 +1157,7 @@ class AiAgentHaPanel extends LitElement {
         }];
         this.requestUpdate();
       }
-    }, 60000); // 60 second timeout
+    }, 300000); // 300 second timeout (matches backend aiohttp timeout)
 
     try {
       console.debug("Calling ai_agent_ha service");


### PR DESCRIPTION
## Problem

Two issues blocked users from running AI Agent HA against a local LM Studio (or other OpenAI-compatible) server:

1. The **Local Model** provider only spoke the Ollama-native API format (`POST /api/generate` with a flat `prompt` string). LM Studio and most other local inference servers (vLLM, LocalAI, llama.cpp server) use the OpenAI-compatible format (`POST /v1/chat/completions` with a `messages` array). Configuring Local Model with an LM Studio URL produced `Unexpected endpoint or method (POST /)` errors.

2. The **frontend panel** had a hardcoded 60-second timeout. Local models on CPU/iGPU hardware commonly take 60–180 seconds to respond to complex HA prompts. The UI showed `Request timed out. Please try again.` and injected a failure message into the chat — even though the backend was still processing and the model would have returned a valid response.

---

## Changes

### `agent.py` — `LocalClient` auto-detects endpoint format

`LocalClient.__init__` now inspects the configured URL for `/v1`. If found, it sends an OpenAI-compatible `messages` array to `POST /v1/chat/completions`. If not found, it falls back to the existing Ollama-native `prompt` string format.

| `local_url` | Request format |
|---|---|
| `http://host:1234/v1` | OpenAI-compatible (`messages` array) |
| `http://host:11434/api/generate` | Ollama-native (`prompt` string) — unchanged |

No behavior change for existing Ollama users.

### `const.py`, `config_flow.py`, `agent.py` — OpenAI provider custom base URL

Adds an optional **Custom Base URL** field to the OpenAI provider configuration. When populated, `OpenAIClient` routes requests to that endpoint instead of `api.openai.com`. The `sk-` prefix check and `len >= 32` key length validation are both bypassed when a custom endpoint is set, since local servers accept any non-empty string as the API key.

Leaving the field blank preserves existing OpenAI API behavior with no changes.

### `frontend/ai_agent_ha-panel.js` — timeout 60s → 300s

Increased the frontend `setTimeout` from 60,000ms to 300,000ms to match the `aiohttp.ClientTimeout(total=300)` already configured on all backend API clients. Prevents false timeout errors on slower local hardware.

---

## Testing

Verified end-to-end with LM Studio serving Qwen3.5-9B on a local network host:

- **Local Model provider** with `http://<host>:1234/v1` → OpenAI-compatible path confirmed in HA logs, full responses returned correctly
- **OpenAI provider** with custom base URL `http://<host>:1234/v1` and API key `lmstudio` → identical behavior
- **Ollama** at `http://localhost:11434/api/generate` → legacy path unchanged, no regression
- Complex entity/dashboard prompts completing in 90–180s without timeout errors

---

## Configuration (LM Studio)

**Option A — Local Model provider:**
| Field | Value |
|---|---|
| Local API URL | `http://<lmstudio-host>:1234/v1` |
| Model | `Custom...` → paste exact model ID from LM Studio server tab |

**Option B — OpenAI provider with custom base URL:**
| Field | Value |
|---|---|
| API Key | `lmstudio` (any non-empty string) |
| Custom Base URL | `http://<lmstudio-host>:1234/v1` |
| Model | `Custom...` → paste exact model ID from LM Studio server tab |