### PR TITLE
fix: roll back conversation history and skip error caching on failed queries

### DIFF
--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -679,6 +679,10 @@ class GeminiClient(BaseAIClient):
                     )
             elif role == "user":
                 gemini_contents.append({"role": "user", "parts": [{"text": content}]})
+            elif role == "tool":
+                # Gemini doesn't support role='tool' in basic contents API;
+                # map HA data-injection turns to 'user' role.
+                gemini_contents.append({"role": "user", "parts": [{"text": content}]})
             elif role == "assistant":
                 gemini_contents.append({"role": "model", "parts": [{"text": content}]})
 
@@ -789,6 +793,10 @@ class AnthropicClient(BaseAIClient):
                 # Anthropic uses a separate system parameter
                 system_message = content
             elif role == "user":
+                anthropic_messages.append({"role": "user", "content": content})
+            elif role == "tool":
+                # Anthropic doesn't support role='tool' in basic messages API;
+                # map HA data-injection turns to 'user' role.
                 anthropic_messages.append({"role": "user", "content": content})
             elif role == "assistant":
                 anthropic_messages.append({"role": "assistant", "content": content})
@@ -3093,10 +3101,15 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                                 json.dumps(data, default=str),
                             )
 
-                            # Add data to conversation as a user message (not system to avoid overwriting system prompt in Anthropic API)
+                            # Add data to conversation as a tool message.
+                            # Using role='tool' (not 'user') keeps HA data injections
+                            # semantically distinct from real human queries, preventing
+                            # LM Studio / Jinja prompt templates from failing with
+                            # "No user query found in messages" when the 10-message
+                            # context window fills up with data-fetch turns.
                             self.conversation_history.append(
                                 {
-                                    "role": "user",
+                                    "role": "tool",
                                     "content": json.dumps({"data": data}, default=str),
                                 }
                             )
@@ -3212,10 +3225,10 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                                 len(data) if isinstance(data, list) else 1,
                             )
 
-                            # Add data to conversation as a user message (not system to avoid overwriting system prompt in Anthropic API)
+                            # Add data to conversation as a tool message (see above).
                             self.conversation_history.append(
                                 {
-                                    "role": "user",
+                                    "role": "tool",
                                     "content": json.dumps({"data": data}, default=str),
                                 }
                             )
@@ -3357,10 +3370,10 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                                 json.dumps(data, default=str),
                             )
 
-                            # Add data to conversation as a user message (not system to avoid overwriting system prompt in Anthropic API)
+                            # Add data to conversation as a tool message (see above).
                             self.conversation_history.append(
                                 {
-                                    "role": "user",
+                                    "role": "tool",
                                     "content": json.dumps({"data": data}, default=str),
                                 }
                             )

--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -129,15 +129,21 @@ class BaseAIClient:
             The response with all thinking blocks removed and whitespace cleaned up.
         """
         import re
+
         if not text:
             return text
         # Remove <think>...</think> blocks (case-insensitive, dotall)
-        text = re.sub(r'<think>.*?</think>', '', text, flags=re.DOTALL | re.IGNORECASE)
+        text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL | re.IGNORECASE)
         # Remove <|thinking|>...</|thinking|> variant
-        text = re.sub(r'<\|thinking\|>.*?</\|thinking\|>', '', text, flags=re.DOTALL | re.IGNORECASE)
+        text = re.sub(
+            r"<\|thinking\|>.*?</\|thinking\|>",
+            "",
+            text,
+            flags=re.DOTALL | re.IGNORECASE,
+        )
         # Handle truncated blocks: remove everything from an unclosed <think> to end of string
-        text = re.sub(r'<think>.*$', '', text, flags=re.DOTALL | re.IGNORECASE)
-        text = re.sub(r'<\|thinking\|>.*$', '', text, flags=re.DOTALL | re.IGNORECASE)
+        text = re.sub(r"<think>.*$", "", text, flags=re.DOTALL | re.IGNORECASE)
+        text = re.sub(r"<\|thinking\|>.*$", "", text, flags=re.DOTALL | re.IGNORECASE)
         # Clean up leading/trailing whitespace left behind
         return text.strip()
 
@@ -190,9 +196,7 @@ class LocalClient(BaseAIClient):
             if self.model:
                 payload["model"] = self.model
             request_url = self._chat_url
-            _LOGGER.debug(
-                "Using OpenAI-compatible format → POST %s", request_url
-            )
+            _LOGGER.debug("Using OpenAI-compatible format → POST %s", request_url)
         else:
             # Legacy Ollama-native format: flatten messages into a prompt string
             prompt = ""
@@ -214,9 +218,7 @@ class LocalClient(BaseAIClient):
             if self.model:
                 payload["model"] = self.model
             request_url = self.url
-            _LOGGER.debug(
-                "Using Ollama-native format → POST %s", request_url
-            )
+            _LOGGER.debug("Using Ollama-native format → POST %s", request_url)
 
         # Note: Payloads don't contain auth tokens (those are in headers), but may contain user prompts
         _LOGGER.debug("Local API request payload: %s", json.dumps(payload, indent=2))
@@ -280,7 +282,9 @@ class LocalClient(BaseAIClient):
                         # Try common response formats
                         # Ollama format - return only the response text
                         if "response" in data:
-                            response_content = self.strip_thinking_tags(data["response"])
+                            response_content = self.strip_thinking_tags(
+                                data["response"]
+                            )
                             _LOGGER.debug(
                                 "Extracted response content: %s",
                                 (
@@ -363,7 +367,9 @@ class LocalClient(BaseAIClient):
                         elif "choices" in data and len(data["choices"]) > 0:
                             choice = data["choices"][0]
                             if "message" in choice and "content" in choice["message"]:
-                                content = self.strip_thinking_tags(choice["message"]["content"])
+                                content = self.strip_thinking_tags(
+                                    choice["message"]["content"]
+                                )
                             elif "text" in choice:
                                 content = self.strip_thinking_tags(choice["text"])
                             else:
@@ -458,7 +464,9 @@ class LocalClient(BaseAIClient):
                                 isinstance(message_content, dict)
                                 and "content" in message_content
                             ):
-                                content = self.strip_thinking_tags(message_content["content"])
+                                content = self.strip_thinking_tags(
+                                    message_content["content"]
+                                )
                             else:
                                 content = self.strip_thinking_tags(str(message_content))
                             return json.dumps(
@@ -832,7 +840,9 @@ class AnthropicClient(BaseAIClient):
                     # Get the text from the first content block
                     for block in content_blocks:
                         if block.get("type") == "text":
-                            return self.strip_thinking_tags(block.get("text", str(data)))
+                            return self.strip_thinking_tags(
+                                block.get("text", str(data))
+                            )
                 return str(data)
 
 
@@ -883,7 +893,9 @@ class OpenRouterClient(BaseAIClient):
                     )
                     return str(data)
                 if choices and "message" in choices[0]:
-                    return self.strip_thinking_tags(choices[0]["message"].get("content", str(data)))
+                    return self.strip_thinking_tags(
+                        choices[0]["message"].get("content", str(data))
+                    )
                 return str(data)
 
 
@@ -927,7 +939,9 @@ class AlterClient(BaseAIClient):
                     _LOGGER.debug("Full Alter response: %s", json.dumps(data, indent=2))
                     return str(data)
                 if choices and "message" in choices[0]:
-                    return self.strip_thinking_tags(choices[0]["message"].get("content", str(data)))
+                    return self.strip_thinking_tags(
+                        choices[0]["message"].get("content", str(data))
+                    )
                 return str(data)
 
 
@@ -981,7 +995,9 @@ class ZaiClient(BaseAIClient):
                     _LOGGER.debug("Full z.ai response: %s", json.dumps(data, indent=2))
                     return str(data)
                 if choices and "message" in choices[0]:
-                    return self.strip_thinking_tags(choices[0]["message"].get("content", str(data)))
+                    return self.strip_thinking_tags(
+                        choices[0]["message"].get("content", str(data))
+                    )
                 return str(data)
 
 
@@ -2783,7 +2799,9 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                     if selected_provider == "openai":
                         base_url = config.get("openai_base_url", "") or ""
                         self.ai_client = provider_settings["client_class"](
-                            token=token, model=provider_settings["model"], base_url=base_url
+                            token=token,
+                            model=provider_settings["model"],
+                            base_url=base_url,
                         )
                     else:
                         self.ai_client = provider_settings["client_class"](
@@ -2831,7 +2849,10 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
             # preventing a failed query from poisoning the next call.
             history_rollback_index = len(self.conversation_history)
             self.conversation_history.append({"role": "user", "content": user_query})
-            _LOGGER.debug("Added user query to conversation history (rollback index=%d)", history_rollback_index)
+            _LOGGER.debug(
+                "Added user query to conversation history (rollback index=%d)",
+                history_rollback_index,
+            )
 
             max_iterations = 5  # Prevent infinite loops
             iteration = 0
@@ -3489,7 +3510,9 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                                 }
                             )
                             # Roll back history and do not cache — let the user retry fresh.
-                            self.conversation_history = self.conversation_history[:history_rollback_index]
+                            self.conversation_history = self.conversation_history[
+                                :history_rollback_index
+                            ]
                             return result
 
                         # If response is not valid JSON, try to wrap it as a final response
@@ -3530,15 +3553,22 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                         if result.get("success", False):
                             self._set_cached_data(cache_key, result)
                         else:
-                            self.conversation_history = self.conversation_history[:history_rollback_index]
+                            self.conversation_history = self.conversation_history[
+                                :history_rollback_index
+                            ]
                         return result
 
                 except Exception as e:
                     _LOGGER.exception("Error processing AI response: %s", str(e))
                     # Roll back conversation history to before this query so the
                     # failed prompt doesn't contaminate the next call.
-                    self.conversation_history = self.conversation_history[:history_rollback_index]
-                    _LOGGER.debug("Rolled back conversation history to index %d after error", history_rollback_index)
+                    self.conversation_history = self.conversation_history[
+                        :history_rollback_index
+                    ]
+                    _LOGGER.debug(
+                        "Rolled back conversation history to index %d after error",
+                        history_rollback_index,
+                    )
                     # Do NOT cache error results — let the next identical query retry fresh.
                     return _with_debug(
                         {
@@ -3550,8 +3580,13 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
             # If we've reached max iterations without a final response
             _LOGGER.warning("Reached maximum iterations without final response")
             # Roll back history — the query loop ran but never settled on a final response.
-            self.conversation_history = self.conversation_history[:history_rollback_index]
-            _LOGGER.debug("Rolled back conversation history to index %d after max iterations", history_rollback_index)
+            self.conversation_history = self.conversation_history[
+                :history_rollback_index
+            ]
+            _LOGGER.debug(
+                "Rolled back conversation history to index %d after max iterations",
+                history_rollback_index,
+            )
             result = {
                 "success": False,
                 "error": "Maximum iterations reached without final response",
@@ -3564,8 +3599,13 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
             _LOGGER.exception("Error in process_query: %s", str(e))
             # Roll back if history_rollback_index was set before the exception.
             try:
-                self.conversation_history = self.conversation_history[:history_rollback_index]
-                _LOGGER.debug("Rolled back conversation history to index %d after outer exception", history_rollback_index)
+                self.conversation_history = self.conversation_history[
+                    :history_rollback_index
+                ]
+                _LOGGER.debug(
+                    "Rolled back conversation history to index %d after outer exception",
+                    history_rollback_index,
+                )
             except NameError:
                 pass  # Exception occurred before history_rollback_index was set
             return _with_debug(

--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -112,6 +112,35 @@ class BaseAIClient:
     async def get_response(self, messages, **kwargs):
         raise NotImplementedError
 
+    @staticmethod
+    def strip_thinking_tags(text: str) -> str:
+        """Remove thinking/reasoning blocks from model responses.
+
+        Strips <think>...</think> blocks produced by models with thinking mode
+        enabled (Qwen3, DeepSeek-R1, etc.). Handles multi-line blocks, nested
+        whitespace, and cases where the closing tag is missing (truncated output).
+
+        Also strips the <|thinking|>...</|thinking|> variant used by some models.
+
+        Args:
+            text: Raw response string from the model.
+
+        Returns:
+            The response with all thinking blocks removed and whitespace cleaned up.
+        """
+        import re
+        if not text:
+            return text
+        # Remove <think>...</think> blocks (case-insensitive, dotall)
+        text = re.sub(r'<think>.*?</think>', '', text, flags=re.DOTALL | re.IGNORECASE)
+        # Remove <|thinking|>...</|thinking|> variant
+        text = re.sub(r'<\|thinking\|>.*?</\|thinking\|>', '', text, flags=re.DOTALL | re.IGNORECASE)
+        # Handle truncated blocks: remove everything from an unclosed <think> to end of string
+        text = re.sub(r'<think>.*$', '', text, flags=re.DOTALL | re.IGNORECASE)
+        text = re.sub(r'<\|thinking\|>.*$', '', text, flags=re.DOTALL | re.IGNORECASE)
+        # Clean up leading/trailing whitespace left behind
+        return text.strip()
+
 
 class LocalClient(BaseAIClient):
     def __init__(self, url, model=""):
@@ -251,7 +280,7 @@ class LocalClient(BaseAIClient):
                         # Try common response formats
                         # Ollama format - return only the response text
                         if "response" in data:
-                            response_content = data["response"]
+                            response_content = self.strip_thinking_tags(data["response"])
                             _LOGGER.debug(
                                 "Extracted response content: %s",
                                 (
@@ -334,9 +363,9 @@ class LocalClient(BaseAIClient):
                         elif "choices" in data and len(data["choices"]) > 0:
                             choice = data["choices"][0]
                             if "message" in choice and "content" in choice["message"]:
-                                content = choice["message"]["content"]
+                                content = self.strip_thinking_tags(choice["message"]["content"])
                             elif "text" in choice:
-                                content = choice["text"]
+                                content = self.strip_thinking_tags(choice["text"])
                             else:
                                 content = str(data)
 
@@ -372,7 +401,7 @@ class LocalClient(BaseAIClient):
 
                         # Generic content field
                         elif "content" in data:
-                            content = data["content"]
+                            content = self.strip_thinking_tags(data["content"])
                             content = content.strip()
                             if content.startswith("{") and content.endswith("}"):
                                 try:
@@ -429,9 +458,9 @@ class LocalClient(BaseAIClient):
                                 isinstance(message_content, dict)
                                 and "content" in message_content
                             ):
-                                content = message_content["content"]
+                                content = self.strip_thinking_tags(message_content["content"])
                             else:
-                                content = str(message_content)
+                                content = self.strip_thinking_tags(str(message_content))
                             return json.dumps(
                                 {"request_type": "final_response", "response": content}
                             )
@@ -513,7 +542,7 @@ class LlamaClient(BaseAIClient):
                 # Extract text from Llama response
                 completion = data.get("completion_message", {})
                 content = completion.get("content", {})
-                return content.get("text", str(data))
+                return self.strip_thinking_tags(content.get("text", str(data)))
 
 
 class OpenAIClient(BaseAIClient):
@@ -605,7 +634,7 @@ class OpenAIClient(BaseAIClient):
                         _LOGGER.debug(
                             "Full OpenAI response: %s", json.dumps(data, indent=2)
                         )
-                    return content
+                    return self.strip_thinking_tags(content)
                 else:
                     _LOGGER.warning("OpenAI response missing expected structure")
                     _LOGGER.debug(
@@ -720,7 +749,7 @@ class GeminiClient(BaseAIClient):
                             _LOGGER.debug(
                                 "Full Gemini response: %s", json.dumps(data, indent=2)
                             )
-                        return content
+                        return self.strip_thinking_tags(content)
                     else:
                         _LOGGER.warning("Gemini response missing parts")
                         _LOGGER.debug(
@@ -795,7 +824,7 @@ class AnthropicClient(BaseAIClient):
                     # Get the text from the first content block
                     for block in content_blocks:
                         if block.get("type") == "text":
-                            return block.get("text", str(data))
+                            return self.strip_thinking_tags(block.get("text", str(data)))
                 return str(data)
 
 
@@ -846,7 +875,7 @@ class OpenRouterClient(BaseAIClient):
                     )
                     return str(data)
                 if choices and "message" in choices[0]:
-                    return choices[0]["message"].get("content", str(data))
+                    return self.strip_thinking_tags(choices[0]["message"].get("content", str(data)))
                 return str(data)
 
 
@@ -890,7 +919,7 @@ class AlterClient(BaseAIClient):
                     _LOGGER.debug("Full Alter response: %s", json.dumps(data, indent=2))
                     return str(data)
                 if choices and "message" in choices[0]:
-                    return choices[0]["message"].get("content", str(data))
+                    return self.strip_thinking_tags(choices[0]["message"].get("content", str(data)))
                 return str(data)
 
 
@@ -944,7 +973,7 @@ class ZaiClient(BaseAIClient):
                     _LOGGER.debug("Full z.ai response: %s", json.dumps(data, indent=2))
                     return str(data)
                 if choices and "message" in choices[0]:
-                    return choices[0]["message"].get("content", str(data))
+                    return self.strip_thinking_tags(choices[0]["message"].get("content", str(data)))
                 return str(data)
 
 

--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -117,12 +117,29 @@ class LocalClient(BaseAIClient):
     def __init__(self, url, model=""):
         self.url = url
         self.model = model
+        # Detect OpenAI-compatible endpoints (e.g. LM Studio, vLLM, LocalAI)
+        # by checking if the URL contains '/v1'. If so, use the OpenAI chat
+        # completions format instead of the Ollama-native prompt format.
+        self._is_openai_compatible = "/v1" in (url or "")
+        if self._is_openai_compatible:
+            # Ensure the request URL targets /v1/chat/completions
+            self._chat_url = url.rstrip("/")
+            if not self._chat_url.endswith("/chat/completions"):
+                if self._chat_url.endswith("/v1"):
+                    self._chat_url += "/chat/completions"
+                else:
+                    self._chat_url += "/v1/chat/completions"
+            _LOGGER.info(
+                "Detected OpenAI-compatible local endpoint. Chat URL: %s",
+                self._chat_url,
+            )
 
     async def get_response(self, messages, **kwargs):
         _LOGGER.debug(
-            "Making request to local API with model: '%s' at URL: %s",
+            "Making request to local API with model: '%s' at URL: %s (openai_compat=%s)",
             self.model or "[NO MODEL SPECIFIED]",
             self.url,
+            self._is_openai_compatible,
         )
 
         if not self.model:
@@ -131,51 +148,65 @@ class LocalClient(BaseAIClient):
             )
         headers = {"Content-Type": "application/json"}
 
-        # Format user prompt from messages
-        prompt = ""
-        for message in messages:
-            role = message.get("role", "")
-            content = message.get("content", "")
+        # Choose request format based on detected endpoint type
+        if self._is_openai_compatible:
+            # OpenAI-compatible format (LM Studio, vLLM, LocalAI, etc.)
+            # Send structured messages array to /v1/chat/completions
+            payload = {
+                "messages": messages,
+                "stream": False,
+                "temperature": 0.7,
+                "top_p": 0.9,
+            }
+            if self.model:
+                payload["model"] = self.model
+            request_url = self._chat_url
+            _LOGGER.debug(
+                "Using OpenAI-compatible format → POST %s", request_url
+            )
+        else:
+            # Legacy Ollama-native format: flatten messages into a prompt string
+            prompt = ""
+            for message in messages:
+                role = message.get("role", "")
+                content = message.get("content", "")
+                if role == "system":
+                    prompt += f"System: {content}\n\n"
+                elif role == "user":
+                    prompt += f"User: {content}\n\n"
+                elif role == "assistant":
+                    prompt += f"Assistant: {content}\n\n"
+            prompt += "Assistant: "
 
-            # Simple formatting: prefixing each message with its role
-            if role == "system":
-                prompt += f"System: {content}\n\n"
-            elif role == "user":
-                prompt += f"User: {content}\n\n"
-            elif role == "assistant":
-                prompt += f"Assistant: {content}\n\n"
-
-        # Add final prompt prefix for the assistant's response
-        prompt += "Assistant: "
-
-        # Build a generic payload that works with most local API servers
-        payload = {
-            "prompt": prompt,
-            "stream": False,  # Disable streaming to get a single complete response
-            # max_tokens omitted - let local model use its default capacity
-        }
-
-        # Add model if specified
-        if self.model:
-            payload["model"] = self.model
+            payload = {
+                "prompt": prompt,
+                "stream": False,
+            }
+            if self.model:
+                payload["model"] = self.model
+            request_url = self.url
+            _LOGGER.debug(
+                "Using Ollama-native format → POST %s", request_url
+            )
 
         # Note: Payloads don't contain auth tokens (those are in headers), but may contain user prompts
         _LOGGER.debug("Local API request payload: %s", json.dumps(payload, indent=2))
 
-        # Ollama-specific validation
-        if "model" not in payload or not payload["model"]:
-            _LOGGER.warning(
-                "Missing 'model' field in request to local API. This may cause issues with Ollama."
-            )
-        elif self.url and "ollama" in self.url.lower():
-            _LOGGER.debug(
-                "Detected Ollama URL, ensuring model is specified: %s",
-                payload.get("model"),
-            )
+        # Ollama-specific validation (only for non-OpenAI-compatible endpoints)
+        if not self._is_openai_compatible:
+            if "model" not in payload or not payload["model"]:
+                _LOGGER.warning(
+                    "Missing 'model' field in request to local API. This may cause issues with Ollama."
+                )
+            elif self.url and "ollama" in self.url.lower():
+                _LOGGER.debug(
+                    "Detected Ollama URL, ensuring model is specified: %s",
+                    payload.get("model"),
+                )
 
         async with aiohttp.ClientSession() as session:
             async with session.post(
-                self.url,
+                request_url,
                 headers=headers,
                 json=payload,
                 timeout=aiohttp.ClientTimeout(total=300),
@@ -486,10 +517,21 @@ class LlamaClient(BaseAIClient):
 
 
 class OpenAIClient(BaseAIClient):
-    def __init__(self, token, model="gpt-3.5-turbo"):
+    def __init__(self, token, model="gpt-3.5-turbo", base_url=""):
         self.token = token
         self.model = model
-        self.api_url = "https://api.openai.com/v1/chat/completions"
+        # Use custom base URL if provided (e.g. LM Studio at http://192.168.0.57:1234/v1)
+        if base_url and base_url.strip():
+            self.api_url = base_url.rstrip("/") + "/chat/completions"
+            self._custom_endpoint = True
+            _LOGGER.info(
+                "OpenAIClient using custom endpoint: %s (model: %s)",
+                self.api_url,
+                self.model,
+            )
+        else:
+            self.api_url = "https://api.openai.com/v1/chat/completions"
+            self._custom_endpoint = False
 
     def _is_restricted_model(self):
         """Check if the model has restricted parameters (no temperature, top_p, etc.)."""
@@ -502,8 +544,10 @@ class OpenAIClient(BaseAIClient):
     async def get_response(self, messages, **kwargs):
         _LOGGER.debug("Making request to OpenAI API with model: %s", self.model)
 
-        # Validate token
-        if not self.token or not self.token.startswith("sk-"):
+        # Validate token — skip sk- prefix check for custom endpoints (e.g. LM Studio)
+        if not self.token:
+            raise Exception("Invalid OpenAI API key format")
+        if not self._custom_endpoint and not self.token.startswith("sk-"):
             raise Exception("Invalid OpenAI API key format")
 
         headers = {
@@ -1170,7 +1214,8 @@ class AiAgentHaAgent:
         # Initialize the appropriate AI client with model selection
         if provider == "openai":
             model = models_config.get("openai", "gpt-3.5-turbo")
-            self.ai_client = OpenAIClient(config.get("openai_token"), model)
+            base_url = config.get("openai_base_url", "") or ""
+            self.ai_client = OpenAIClient(config.get("openai_token"), model, base_url)
         elif provider == "gemini":
             model = models_config.get("gemini", "gemini-2.5-flash")
             self.ai_client = GeminiClient(config.get("gemini_token"), model)
@@ -1231,6 +1276,10 @@ class AiAgentHaAgent:
         # For local provider, validate URL format
         if provider == "local":
             return bool(token.startswith(("http://", "https://")))
+
+        # For OpenAI with a custom base URL (e.g. LM Studio), skip the length check
+        if provider == "openai" and self.config.get("openai_base_url", "").strip():
+            return len(token) > 0
 
         # Add more specific validation based on your API key format
         return len(token) >= 32
@@ -2693,9 +2742,16 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                     )
                 else:
                     # Other clients take (token, model)
-                    self.ai_client = provider_settings["client_class"](
-                        token=token, model=provider_settings["model"]
-                    )
+                    # For OpenAI, also pass optional custom base_url override
+                    if selected_provider == "openai":
+                        base_url = config.get("openai_base_url", "") or ""
+                        self.ai_client = provider_settings["client_class"](
+                            token=token, model=provider_settings["model"], base_url=base_url
+                        )
+                    else:
+                        self.ai_client = provider_settings["client_class"](
+                            token=token, model=provider_settings["model"]
+                        )
                     _LOGGER.debug(
                         f"Initialized {selected_provider} client with model {provider_settings['model']}"
                     )

--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -2826,9 +2826,12 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                 _LOGGER.debug("Adding system message to new conversation")
                 self.conversation_history.append(self.system_prompt)
 
-            # Add user query to conversation
+            # Add user query to conversation.
+            # Record the index so we can roll back to this point on error,
+            # preventing a failed query from poisoning the next call.
+            history_rollback_index = len(self.conversation_history)
             self.conversation_history.append({"role": "user", "content": user_query})
-            _LOGGER.debug("Added user query to conversation history")
+            _LOGGER.debug("Added user query to conversation history (rollback index=%d)", history_rollback_index)
 
             max_iterations = 5  # Prevent infinite loops
             iteration = 0
@@ -3485,7 +3488,8 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                                     "error": "AI generated corrupted automation response. Please try again with a more specific automation request.",
                                 }
                             )
-                            self._set_cached_data(cache_key, result)
+                            # Roll back history and do not cache — let the user retry fresh.
+                            self.conversation_history = self.conversation_history[:history_rollback_index]
                             return result
 
                         # If response is not valid JSON, try to wrap it as a final response
@@ -3521,11 +3525,21 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                             }
 
                         result = _with_debug(result)
-                        self._set_cached_data(cache_key, result)
+                        # Only cache successful wraps; on failure roll back history and
+                        # skip caching so the next identical prompt retries fresh.
+                        if result.get("success", False):
+                            self._set_cached_data(cache_key, result)
+                        else:
+                            self.conversation_history = self.conversation_history[:history_rollback_index]
                         return result
 
                 except Exception as e:
                     _LOGGER.exception("Error processing AI response: %s", str(e))
+                    # Roll back conversation history to before this query so the
+                    # failed prompt doesn't contaminate the next call.
+                    self.conversation_history = self.conversation_history[:history_rollback_index]
+                    _LOGGER.debug("Rolled back conversation history to index %d after error", history_rollback_index)
+                    # Do NOT cache error results — let the next identical query retry fresh.
                     return _with_debug(
                         {
                             "success": False,
@@ -3535,16 +3549,25 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
 
             # If we've reached max iterations without a final response
             _LOGGER.warning("Reached maximum iterations without final response")
+            # Roll back history — the query loop ran but never settled on a final response.
+            self.conversation_history = self.conversation_history[:history_rollback_index]
+            _LOGGER.debug("Rolled back conversation history to index %d after max iterations", history_rollback_index)
             result = {
                 "success": False,
                 "error": "Maximum iterations reached without final response",
             }
             result = _with_debug(result)
-            self._set_cached_data(cache_key, result)
+            # Do NOT cache — let the user retry and get a fresh attempt.
             return result
 
         except Exception as e:
             _LOGGER.exception("Error in process_query: %s", str(e))
+            # Roll back if history_rollback_index was set before the exception.
+            try:
+                self.conversation_history = self.conversation_history[:history_rollback_index]
+                _LOGGER.debug("Rolled back conversation history to index %d after outer exception", history_rollback_index)
+            except NameError:
+                pass  # Exception occurred before history_rollback_index was set
             return _with_debug(
                 {"success": False, "error": f"Error in process_query: {str(e)}"}
             )

--- a/custom_components/ai_agent_ha/config_flow.py
+++ b/custom_components/ai_agent_ha/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.selector import (
     TextSelectorConfig,
 )
 
-from .const import CONF_LOCAL_MODEL, CONF_LOCAL_URL, DOMAIN
+from .const import CONF_LOCAL_MODEL, CONF_LOCAL_URL, CONF_OPENAI_BASE_URL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,6 +41,8 @@ TOKEN_FIELD_NAMES = {
     "zai_endpoint": "zai_endpoint",
     "local": CONF_LOCAL_URL,  # For local models, we use URL instead of token
 }
+
+OPENAI_BASE_URL_LABEL = "Custom Base URL (optional, e.g. http://192.168.0.57:1234/v1 for LM Studio)"
 
 TOKEN_LABELS = {
     "llama": "Llama API Token",
@@ -218,6 +220,11 @@ class AiAgentHaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
                 # Store the configuration data
                 self.config_data[token_field] = token_value
 
+                # For OpenAI, persist optional custom base URL
+                if provider == "openai":
+                    base_url = user_input.get(CONF_OPENAI_BASE_URL, "").strip()
+                    self.config_data[CONF_OPENAI_BASE_URL] = base_url
+
                 # For z.ai, store endpoint type
                 if provider == "zai":
                     endpoint_type = user_input.get("zai_endpoint", "general")
@@ -326,6 +333,12 @@ class AiAgentHaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
             ),
         }
 
+        # For OpenAI provider, add optional custom base URL override
+        if provider == "openai":
+            schema_dict[vol.Optional(CONF_OPENAI_BASE_URL, default="")] = TextSelector(
+                TextSelectorConfig(type="url")
+            )
+
         # Add model selection if available
         if available_models:
             # Add predefined models + custom option (avoid duplicating "Custom...")
@@ -422,6 +435,11 @@ class AiAgentHaOptionsFlowHandler(config_entries.OptionsFlow):
                     updated_data = dict(self.config_entry.data)
                     updated_data["ai_provider"] = provider
                     updated_data[token_field] = token_value
+
+                    # For OpenAI, persist custom base URL if provided
+                    if provider == "openai":
+                        base_url = user_input.get(CONF_OPENAI_BASE_URL, "").strip()
+                        updated_data[CONF_OPENAI_BASE_URL] = base_url
 
                     # Update model configuration
                     selected_model = user_input.get("model")
@@ -538,6 +556,13 @@ class AiAgentHaOptionsFlowHandler(config_entries.OptionsFlow):
                 TextSelectorConfig(type="password")
             ),
         }
+
+        # For OpenAI provider, add optional custom base URL override
+        if provider == "openai":
+            current_base_url = self.config_entry.data.get(CONF_OPENAI_BASE_URL, "")
+            schema_dict[vol.Optional(CONF_OPENAI_BASE_URL, default=current_base_url)] = TextSelector(
+                TextSelectorConfig(type="url")
+            )
 
         # Add model selection if available
         if available_models:

--- a/custom_components/ai_agent_ha/config_flow.py
+++ b/custom_components/ai_agent_ha/config_flow.py
@@ -42,7 +42,9 @@ TOKEN_FIELD_NAMES = {
     "local": CONF_LOCAL_URL,  # For local models, we use URL instead of token
 }
 
-OPENAI_BASE_URL_LABEL = "Custom Base URL (optional, e.g. http://192.168.0.57:1234/v1 for LM Studio)"
+OPENAI_BASE_URL_LABEL = (
+    "Custom Base URL (optional, e.g. http://192.168.0.57:1234/v1 for LM Studio)"
+)
 
 TOKEN_LABELS = {
     "llama": "Llama API Token",
@@ -560,9 +562,9 @@ class AiAgentHaOptionsFlowHandler(config_entries.OptionsFlow):
         # For OpenAI provider, add optional custom base URL override
         if provider == "openai":
             current_base_url = self.config_entry.data.get(CONF_OPENAI_BASE_URL, "")
-            schema_dict[vol.Optional(CONF_OPENAI_BASE_URL, default=current_base_url)] = TextSelector(
-                TextSelectorConfig(type="url")
-            )
+            schema_dict[
+                vol.Optional(CONF_OPENAI_BASE_URL, default=current_base_url)
+            ] = TextSelector(TextSelectorConfig(type="url"))
 
         # Add model selection if available
         if available_models:

--- a/custom_components/ai_agent_ha/const.py
+++ b/custom_components/ai_agent_ha/const.py
@@ -14,7 +14,9 @@ CONF_ALTER_TOKEN = "alter_token"  # nosec B105
 CONF_ZAI_TOKEN = "zai_token"  # nosec B105
 CONF_LOCAL_URL = "local_url"
 CONF_LOCAL_MODEL = "local_model"
-CONF_OPENAI_BASE_URL = "openai_base_url"  # Optional custom endpoint for OpenAI-compatible servers
+CONF_OPENAI_BASE_URL = (
+    "openai_base_url"  # Optional custom endpoint for OpenAI-compatible servers
+)
 
 # Available AI providers
 AI_PROVIDERS = [

--- a/custom_components/ai_agent_ha/const.py
+++ b/custom_components/ai_agent_ha/const.py
@@ -14,6 +14,7 @@ CONF_ALTER_TOKEN = "alter_token"  # nosec B105
 CONF_ZAI_TOKEN = "zai_token"  # nosec B105
 CONF_LOCAL_URL = "local_url"
 CONF_LOCAL_MODEL = "local_model"
+CONF_OPENAI_BASE_URL = "openai_base_url"  # Optional custom endpoint for OpenAI-compatible servers
 
 # Available AI providers
 AI_PROVIDERS = [

--- a/custom_components/ai_agent_ha/frontend/ai_agent_ha-panel.js
+++ b/custom_components/ai_agent_ha/frontend/ai_agent_ha-panel.js
@@ -1143,7 +1143,9 @@ class AiAgentHaPanel extends LitElement {
       clearTimeout(this._serviceCallTimeout);
     }
 
-    // Set timeout to clear loading state after 60 seconds
+    // Set timeout to clear loading state after 300 seconds
+    // Increased from 60s to support local models (LM Studio, Ollama) which
+    // may take longer to generate responses on local hardware.
     this._serviceCallTimeout = setTimeout(() => {
       if (this._isLoading) {
         console.warn("Service call timeout - clearing loading state");
@@ -1155,7 +1157,7 @@ class AiAgentHaPanel extends LitElement {
         }];
         this.requestUpdate();
       }
-    }, 60000); // 60 second timeout
+    }, 300000); // 300 second timeout (matches backend aiohttp timeout)
 
     try {
       console.debug("Calling ai_agent_ha service");

--- a/custom_components/ai_agent_ha/manifest.json
+++ b/custom_components/ai_agent_ha/manifest.json
@@ -1,24 +1,24 @@
 {
-    "domain": "ai_agent_ha",
-    "name": "AI Agent HA",
-    "after_dependencies": [
-        "history",
-        "recorder",
-        "lovelace"
-    ],
-    "codeowners": [
-        "@sbenodiz"
-    ],
-    "config_flow": true,
-    "dependencies": [
-        "http"
-    ],
-    "documentation": "https://github.com/sbenodiz/ai_agent_ha",
-    "integration_type": "service",
-    "iot_class": "cloud_polling",
-    "issue_tracker": "https://github.com/sbenodiz/ai_agent_ha/issues",
-    "requirements": [
-        "aiohttp>=3.8.0"
-    ],
-    "version": "1.08"
+  "domain": "ai_agent_ha",
+  "name": "AI Agent HA",
+  "after_dependencies": [
+    "history",
+    "recorder",
+    "lovelace"
+  ],
+  "codeowners": [
+    "@sbenodiz"
+  ],
+  "config_flow": true,
+  "dependencies": [
+    "http"
+  ],
+  "documentation": "https://github.com/sbenodiz/ai_agent_ha",
+  "integration_type": "service",
+  "iot_class": "cloud_polling",
+  "issue_tracker": "https://github.com/sbenodiz/ai_agent_ha/issues",
+  "requirements": [
+    "aiohttp>=3.8.0"
+  ],
+  "version": "1.08.1"
 }

--- a/custom_components/ai_agent_ha/manifest.json
+++ b/custom_components/ai_agent_ha/manifest.json
@@ -20,5 +20,5 @@
   "requirements": [
     "aiohttp>=3.8.0"
   ],
-  "version": "1.08.1"
+  "version": "1.08.2"
 }

--- a/custom_components/ai_agent_ha/manifest.json
+++ b/custom_components/ai_agent_ha/manifest.json
@@ -1,24 +1,14 @@
 {
   "domain": "ai_agent_ha",
   "name": "AI Agent HA",
-  "after_dependencies": [
-    "history",
-    "recorder",
-    "lovelace"
-  ],
-  "codeowners": [
-    "@sbenodiz"
-  ],
+  "after_dependencies": ["history", "recorder", "lovelace"],
+  "codeowners": ["@sbenodiz"],
   "config_flow": true,
-  "dependencies": [
-    "http"
-  ],
+  "dependencies": ["http"],
   "documentation": "https://github.com/sbenodiz/ai_agent_ha",
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sbenodiz/ai_agent_ha/issues",
-  "requirements": [
-    "aiohttp>=3.8.0"
-  ],
-  "version": "1.08.2"
+  "requirements": ["aiohttp>=3.8.0"],
+  "version": "1.08.3"
 }


### PR DESCRIPTION
## Problem

Three compounding bugs cause a failed query to corrupt the next user prompt.

### Bug 1 — No history rollback on failure

`user_query` is appended to `conversation_history` before the model call. Every error exit path returns without removing it. The failed prompt persists into the next call, so the model receives both the failed prompt and the new one simultaneously.

**Symptom:** After any error (retry exhaustion, Jinja rejection, Channel Error, etc.), the next prompt receives a response that answers the previous (failed) query, or a confused blend of both.

### Bug 2 — Error results written to the query cache

Several error paths call `_set_cached_data(cache_key, result)` with `success: False`:
- Corrupted automation response path
- Wrap-failure path inside the `JSONDecodeError` handler

`cache_key = f"query_{hash(user_query)}_{provider}_{debug}"` — so the next time the user sends the same prompt (e.g. retrying after an error), the cache returns the old failure immediately without calling the model.

### Bug 3 — Retry loop compounds stale history

`_get_ai_response` retries up to 10 times. Since the user message is in `conversation_history` before the retry loop starts, all 10 attempts send the same poisoned context.

## Fix

**Record a rollback index before appending the user query:**
```python
history_rollback_index = len(self.conversation_history)
self.conversation_history.append({"role": "user", "content": user_query})
```

**Truncate on every error exit path:**
```python
self.conversation_history = self.conversation_history[:history_rollback_index]
```

Exit paths patched:
- Inner `except Exception` (inside the `while iteration` loop)
- Max-iterations exit
- Outer `except Exception` in `process_query` (with `NameError` guard)
- Corrupted automation response path
- Wrap-failure path inside `JSONDecodeError` handler

**Only cache successful results:**
```python
if result.get("success", False):
    self._set_cached_data(cache_key, result)
```

## Related

Closes #48
