### PR TITLE
fix(agent): cap conversation_history at 50 entries to prevent token-limit failures

### DIFF
--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -1152,6 +1152,7 @@ class AiAgentHaAgent:
         self._last_request_time = 0
         self._request_count = 0
         self._request_window_start = time.time()
+        self._max_history_len = 50  # Max conversation_history entries (system prompt + 49 turns)
 
         provider = config.get("ai_provider", "openai")
         models_config = config.get("models", {})
@@ -1234,6 +1235,19 @@ class AiAgentHaAgent:
 
         # Add more specific validation based on your API key format
         return len(token) >= 32
+
+    def _trim_history(self) -> None:
+        """Trim conversation_history to the last _max_history_len entries.
+
+        Preserves the system prompt at position 0 when trimming, so the
+        model always has the instruction context available.
+        """
+        if len(self.conversation_history) > self._max_history_len:
+            tail_size = self._max_history_len - 1
+            self.conversation_history = (
+                [self.conversation_history[0]]
+                + self.conversation_history[-tail_size:]
+            )
 
     def _check_rate_limit(self) -> bool:
         """Check if we're within rate limits."""
@@ -3039,6 +3053,7 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                             }
                             result = _with_debug(result)
                             self._set_cached_data(cache_key, result)
+                            self._trim_history()
                             return result
                         elif (
                             response_data.get("request_type") == "automation_suggestion"
@@ -3064,6 +3079,7 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                             }
                             result = _with_debug(result)
                             self._set_cached_data(cache_key, result)
+                            self._trim_history()
                             return result
                         elif (
                             response_data.get("request_type") == "dashboard_suggestion"
@@ -3089,6 +3105,7 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                             }
                             result = _with_debug(result)
                             self._set_cached_data(cache_key, result)
+                            self._trim_history()
                             return result
                         elif response_data.get("request_type") in [
                             "get_entities",
@@ -3424,6 +3441,7 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
 
                         result = _with_debug(result)
                         self._set_cached_data(cache_key, result)
+                        self._trim_history()
                         return result
 
                 except Exception as e:

--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -1152,7 +1152,9 @@ class AiAgentHaAgent:
         self._last_request_time = 0
         self._request_count = 0
         self._request_window_start = time.time()
-        self._max_history_len = 50  # Max conversation_history entries (system prompt + 49 turns)
+        self._max_history_len = (
+            50  # Max conversation_history entries (system prompt + 49 turns)
+        )
 
         provider = config.get("ai_provider", "openai")
         models_config = config.get("models", {})
@@ -1244,10 +1246,9 @@ class AiAgentHaAgent:
         """
         if len(self.conversation_history) > self._max_history_len:
             tail_size = self._max_history_len - 1
-            self.conversation_history = (
-                [self.conversation_history[0]]
-                + self.conversation_history[-tail_size:]
-            )
+            self.conversation_history = [
+                self.conversation_history[0]
+            ] + self.conversation_history[-tail_size:]
 
     def _check_rate_limit(self) -> bool:
         """Check if we're within rate limits."""


### PR DESCRIPTION
## Problem

`conversation_history` grows without bound over long sessions. After enough turns the accumulated messages exceed the model's context window, causing API failures (`400 context_length_exceeded`) and degraded response quality.

## Fix

- Added `self._max_history_len = 50` to `AiAgentHaAgent.__init__`
- Added `_trim_history()` method that preserves the system prompt at index 0 and keeps the most recent 49 messages
- `_trim_history()` is called at all 4 success return points in `process_query`

## Behaviour

| History length | After trim |
|---|---|
| ≤ 50 | No change |
| 201 messages | 1 system + 49 most-recent = 50 |

System prompt is always preserved so the model retains its instructions.

Related: companion to #52 (asyncio.Lock for concurrent access)