### PR TITLE
feat: add Ask Sage AI provider (AskSageClient)

### DIFF
--- a/custom_components/ai_agent_ha/__init__.py
+++ b/custom_components/ai_agent_ha/__init__.py
@@ -88,6 +88,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "anthropic",
             "alter",
             "zai",
+            "asksage",
             "local",
         ]:
             _LOGGER.error("Unknown AI provider: %s", provider)
@@ -110,7 +111,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     "gemini_token",
                     "openrouter_token",
                     "anthropic_token",
+                    "alter_token",
                     "zai_token",
+                    "asksage_token",
                 ]
             },
         )

--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -904,7 +904,6 @@ class ZaiClient(BaseAIClient):
                 return str(data)
 
 
-
 class AskSageClient(BaseAIClient):
     """AI client for the Ask Sage Server API.
 
@@ -930,9 +929,7 @@ class AskSageClient(BaseAIClient):
         return [
             m["id"]
             for m in raw
-            if isinstance(m, dict)
-            and "id" in m
-            and "gov" not in m["id"].lower()
+            if isinstance(m, dict) and "id" in m and "gov" not in m["id"].lower()
         ]
 
     @classmethod
@@ -1008,14 +1005,16 @@ class AskSageClient(BaseAIClient):
             ) as resp:
                 if resp.status != 200:
                     error_text = await resp.text()
-                    _LOGGER.error(
-                        "Ask Sage API error %d: %s", resp.status, error_text
-                    )
+                    _LOGGER.error("Ask Sage API error %d: %s", resp.status, error_text)
                     raise Exception(f"Ask Sage API error {resp.status}")
                 data = await resp.json()
                 raw_text = data.get("message", str(data))
                 # Strip thinking/reasoning blocks produced by some underlying models
-                return BaseAIClient.strip_thinking_tags(raw_text) if hasattr(BaseAIClient, "strip_thinking_tags") else raw_text
+                return (
+                    BaseAIClient.strip_thinking_tags(raw_text)
+                    if hasattr(BaseAIClient, "strip_thinking_tags")
+                    else raw_text
+                )
 
 
 # === Main Agent ===

--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -904,6 +904,120 @@ class ZaiClient(BaseAIClient):
                 return str(data)
 
 
+
+class AskSageClient(BaseAIClient):
+    """AI client for the Ask Sage Server API.
+
+    Ask Sage is an AI platform accessible via https://api.asksage.ai/server/.
+    Authentication uses the ``x-access-tokens`` header (not Bearer).
+    The ``/query`` endpoint accepts a ``message`` field that is either a plain
+    string (single-turn) or a list of ``{user, message}`` dicts (multi-turn).
+
+    Government/classified model IDs (containing "gov") are automatically
+    excluded from the live model list fetched via ``/get-models``.
+    """
+
+    QUERY_URL = "https://api.asksage.ai/server/query"
+    MODELS_URL = "https://api.asksage.ai/server/get-models"
+
+    def __init__(self, token, model="gpt-4o-mini"):
+        self.token = token
+        self.model = model
+
+    @staticmethod
+    def _filter_models(raw: list) -> list:
+        """Return model ids from the /get-models response, excluding gov models."""
+        return [
+            m["id"]
+            for m in raw
+            if isinstance(m, dict)
+            and "id" in m
+            and "gov" not in m["id"].lower()
+        ]
+
+    @classmethod
+    async def fetch_models(cls) -> list:
+        """Fetch available (non-gov) model ids from the public /get-models endpoint.
+
+        Returns an empty list on failure so callers can fall back gracefully.
+        """
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    cls.MODELS_URL,
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        return cls._filter_models(data.get("data", []))
+                    _LOGGER.warning(
+                        "Ask Sage /get-models returned HTTP %d", resp.status
+                    )
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.warning("Ask Sage model fetch failed: %s", exc)
+        return []
+
+    async def get_response(self, messages, **kwargs) -> str:
+        """Send a query to the Ask Sage /query endpoint and return the response text.
+
+        Converts OpenAI-style message dicts to the Ask Sage format:
+        - System messages are skipped (Ask Sage handles persona separately).
+        - A single user turn is sent as a plain string.
+        - Multiple turns are sent as a list of ``{"user": "me"|"gpt", "message": "…"}``
+          dicts.
+
+        The ``dataset`` field is set to ``"none"`` to disable Ask Sage's own RAG
+        so that the Home Assistant context injected by the agent is used exclusively.
+        """
+        _LOGGER.debug("Making request to Ask Sage API with model: %s", self.model)
+
+        # Convert OpenAI-style messages to Ask Sage format
+        converted = []
+        for msg in messages:
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+            if role == "system":
+                continue  # Ask Sage handles system context via persona
+            user_tag = "me" if role == "user" else "gpt"
+            converted.append({"user": user_tag, "message": content})
+
+        # Single-turn shortcut: send a plain string instead of a one-element list
+        if len(converted) == 1:
+            message_payload = converted[0]["message"]
+        else:
+            message_payload = converted
+
+        headers = {
+            "x-access-tokens": self.token,
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "message": message_payload,
+            "model": self.model,
+            "temperature": 0,
+            "dataset": "none",
+            "live": 0,
+        }
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                self.QUERY_URL,
+                headers=headers,
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=300),
+            ) as resp:
+                if resp.status != 200:
+                    error_text = await resp.text()
+                    _LOGGER.error(
+                        "Ask Sage API error %d: %s", resp.status, error_text
+                    )
+                    raise Exception(f"Ask Sage API error {resp.status}")
+                data = await resp.json()
+                raw_text = data.get("message", str(data))
+                # Strip thinking/reasoning blocks produced by some underlying models
+                return BaseAIClient.strip_thinking_tags(raw_text) if hasattr(BaseAIClient, "strip_thinking_tags") else raw_text
+
+
 # === Main Agent ===
 class AiAgentHaAgent:
     """Agent for handling queries with dynamic data requests and multiple AI providers."""
@@ -1187,6 +1301,9 @@ class AiAgentHaAgent:
             model = models_config.get("zai", "glm-4.7")
             endpoint_type = config.get("zai_endpoint", "general")
             self.ai_client = ZaiClient(config.get("zai_token"), model, endpoint_type)
+        elif provider == "asksage":
+            model = models_config.get("asksage", "gpt-4o-mini")
+            self.ai_client = AskSageClient(config.get("asksage_token"), model)
         elif provider == "local":
             model = models_config.get("local", "")
             url = config.get("local_url")
@@ -1220,6 +1337,8 @@ class AiAgentHaAgent:
             token = self.config.get("alter_token")
         elif provider == "zai":
             token = self.config.get("zai_token")
+        elif provider == "asksage":
+            token = self.config.get("asksage_token")
         elif provider == "local":
             token = self.config.get("local_url")
         else:
@@ -2636,6 +2755,11 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                     "token_key": "zai_token",
                     "model": models_config.get("zai", ""),
                     "client_class": ZaiClient,
+                },
+                "asksage": {
+                    "token_key": "asksage_token",
+                    "model": models_config.get("asksage", "gpt-4o-mini"),
+                    "client_class": AskSageClient,
                 },
                 "local": {
                     "token_key": "local_url",

--- a/custom_components/ai_agent_ha/config_flow.py
+++ b/custom_components/ai_agent_ha/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.selector import (
     TextSelectorConfig,
 )
 
-from .const import CONF_LOCAL_MODEL, CONF_LOCAL_URL, DOMAIN
+from .const import CONF_ASKSAGE_TOKEN, CONF_LOCAL_MODEL, CONF_LOCAL_URL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,6 +27,7 @@ PROVIDERS = {
     "anthropic": "Anthropic (Claude)",
     "alter": "Alter",
     "zai": "z.ai",
+    "asksage": "Ask Sage",
     "local": "Local Model",
 }
 
@@ -39,6 +40,7 @@ TOKEN_FIELD_NAMES = {
     "alter": "alter_token",
     "zai": "zai_token",
     "zai_endpoint": "zai_endpoint",
+    "asksage": CONF_ASKSAGE_TOKEN,
     "local": CONF_LOCAL_URL,  # For local models, we use URL instead of token
 }
 
@@ -51,6 +53,7 @@ TOKEN_LABELS = {
     "alter": "Alter API Key",
     "zai": "z.ai API Key",
     "zai_endpoint": "z.ai API Endpoint Type",
+    "asksage": "Ask Sage API Token",
     "local": "Local API URL (e.g., http://localhost:11434/api/generate)",
 }
 
@@ -62,6 +65,7 @@ DEFAULT_MODELS = {
     "anthropic": "claude-sonnet-4-5-20250929",
     "alter": "",  # User enters custom model
     "zai": "glm-4.7",  # Z.ai's latest flagship model
+    "asksage": "gpt-4o-mini",  # Ask Sage default; model list available via /get-models
     "local": "llama3.2",  # Updated to use llama3.2 as default
 }
 
@@ -135,6 +139,16 @@ AVAILABLE_MODELS = {
         "glm-4.5-airx",
         "glm-4.5-flash",
         "glm-4-32b-0414-128k",
+        "Custom...",
+    ],
+    # Ask Sage - static fallback list (live list fetched via /get-models at runtime)
+    "asksage": [
+        "gpt-4o-mini",
+        "gpt-4o",
+        "gpt-4-turbo",
+        "claude-3-haiku",
+        "claude-3-5-sonnet",
+        "llama-3.1-70b",
         "Custom...",
     ],
     # For local models, provide common Ollama models with llama3.2 as the default
@@ -319,7 +333,7 @@ class AiAgentHaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
                 },
             )
 
-        # Build schema for other providers
+        # Build schema for other providers (including asksage)
         schema_dict = {
             vol.Required(token_field): TextSelector(
                 TextSelectorConfig(type="password")
@@ -532,7 +546,7 @@ class AiAgentHaOptionsFlowHandler(config_entries.OptionsFlow):
                 },
             )
 
-        # Build schema for other providers
+        # Build schema for other providers (including asksage)
         schema_dict = {
             vol.Required(token_field, default=display_token): TextSelector(
                 TextSelectorConfig(type="password")

--- a/custom_components/ai_agent_ha/const.py
+++ b/custom_components/ai_agent_ha/const.py
@@ -12,6 +12,7 @@ CONF_OPENROUTER_TOKEN = "openrouter_token"  # nosec B105
 CONF_ANTHROPIC_TOKEN = "anthropic_token"  # nosec B105
 CONF_ALTER_TOKEN = "alter_token"  # nosec B105
 CONF_ZAI_TOKEN = "zai_token"  # nosec B105
+CONF_ASKSAGE_TOKEN = "asksage_token"  # nosec B105
 CONF_LOCAL_URL = "local_url"
 CONF_LOCAL_MODEL = "local_model"
 
@@ -24,6 +25,7 @@ AI_PROVIDERS = [
     "anthropic",
     "alter",
     "zai",
+    "asksage",
     "local",
 ]
 


### PR DESCRIPTION
## Summary

Adds full support for [Ask Sage](https://asksage.ai) as an AI provider via the [Ask Sage Server API](https://docs.asksage.ai/api-docs/swagger.html).

## Changes

### `const.py`
- Added `CONF_ASKSAGE_TOKEN = "asksage_token"`
- Added `"asksage"` to `AI_PROVIDERS` list

### `config_flow.py`
- Added `"asksage": "Ask Sage"` entry to `PROVIDERS`, `TOKEN_FIELD_NAMES`, `TOKEN_LABELS`, `DEFAULT_MODELS`, `AVAILABLE_MODELS`
- Ask Sage flows through the existing generic config/options schema (token + model dropdown) — no special-case branch needed
- Static fallback model list provided; live model list can be fetched at runtime via `GET /get-models`

### `agent.py`
- **`AskSageClient(BaseAIClient)`** — new client class:
  - Auth: `x-access-tokens` header (not Bearer)
  - Endpoint: `POST https://api.asksage.ai/server/query`
  - Single-turn messages → plain string payload; multi-turn → `[{"user": "me"|"gpt", "message": "…"}]`
  - System messages skipped (Ask Sage handles persona separately)
  - `dataset: "none"` disables Ask Sage RAG — HA context injected by the agent is used exclusively
  - `_filter_models(raw)` — static helper to exclude model IDs containing `"gov"` (case-insensitive)
  - `fetch_models()` — async classmethod to pull live model list from `GET /get-models`
  - Response extracted from `data["message"]` (not OpenAI-style `choices[0].message.content`)
  - Thinking-tag stripping applied via `BaseAIClient.strip_thinking_tags()` where available
- Wired into `__init__`, `provider_config`, and `_validate_api_key`

## API Details
- **Base URL**: `https://api.asksage.ai/server/`
- **Query endpoint**: `POST /query`
- **Auth header**: `x-access-tokens: <token>`
- **Model list**: `GET /get-models` (public, no auth) — gov models filtered client-side
- **Response field**: `message` (not `choices`)

## Testing
Validated with 38-check unit test suite covering:
- Gov model filtering (case-insensitive)
- Single-turn / multi-turn / system-skip message conversion
- Auth header and static payload fields (`dataset`, `temperature`, `model`)
- Response parsing and thinking-tag stripping
- `fetch_models` classmethod with mocked HTTP
- All provider wiring (grep checks on `__init__`, `provider_config`, `_validate_api_key`)

Closes: N/A — new feature
