### PR TITLE
fix: derive provider allowlist from AI_PROVIDERS constant in __init__.py

### DIFF
--- a/custom_components/ai_agent_ha/__init__.py
+++ b/custom_components/ai_agent_ha/__init__.py
@@ -88,6 +88,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "anthropic",
             "alter",
             "zai",
+            "asksage",
             "local",
         ]:
             _LOGGER.error("Unknown AI provider: %s", provider)
@@ -110,7 +111,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     "gemini_token",
                     "openrouter_token",
                     "anthropic_token",
+                    "alter_token",
                     "zai_token",
+                    "asksage_token",
                 ]
             },
         )

--- a/custom_components/ai_agent_ha/__init__.py
+++ b/custom_components/ai_agent_ha/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from .agent import AiAgentHaAgent
-from .const import DOMAIN
+from .const import AI_PROVIDERS, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -79,18 +79,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         provider = config_data["ai_provider"]
 
-        # Validate provider
-        if provider not in [
-            "llama",
-            "openai",
-            "gemini",
-            "openrouter",
-            "anthropic",
-            "alter",
-            "zai",
-            "asksage",
-            "local",
-        ]:
+        # Validate provider — derived from AI_PROVIDERS in const.py so this
+        # check stays in sync automatically whenever a new provider is added.
+        if provider not in AI_PROVIDERS:
             _LOGGER.error("Unknown AI provider: %s", provider)
             raise ConfigEntryNotReady(f"Unknown AI provider: {provider}")
 


### PR DESCRIPTION
## Problem

`async_setup_entry` in `__init__.py` contained a hardcoded provider allowlist that gated config entry loading:

```python
if provider not in [
    "llama", "openai", "gemini", "openrouter", "anthropic", "alter", "zai", "local",
]:
    raise ConfigEntryNotReady(f"Unknown AI provider: {provider}")
```

This created a **three-place maintenance burden**: every new provider had to be added separately to `agent.py`, `config_flow.py`, _and_ this hardcoded list in `__init__.py`. Missing any one of them caused silent failures — specifically, when Ask Sage was added, the config entry threw `ConfigEntryNotReady` at startup and HA silently routed all prompts to the previously registered provider.

## Fix

**Import `AI_PROVIDERS` from `const.py` and use it directly** — the allowlist now stays in sync automatically whenever a new provider is added to `const.py`.

```python
# Before — __init__.py
from .const import DOMAIN

if provider not in ["llama", "openai", "gemini", ...]:  # manually maintained
    raise ConfigEntryNotReady(...)
```

```python
# After — __init__.py
from .const import AI_PROVIDERS, DOMAIN

# Derived from AI_PROVIDERS in const.py — stays in sync automatically
if provider not in AI_PROVIDERS:
    raise ConfigEntryNotReady(...)
```

**Also fixed:** the debug-log token sanitization exclusion list was missing `"alter_token"` and `"asksage_token"`, meaning those tokens could appear in plaintext in debug logs.

## Files changed

- `custom_components/ai_agent_ha/__init__.py`
  - Import `AI_PROVIDERS` from `const.py`
  - Replace hardcoded allowlist with `if provider not in AI_PROVIDERS`
  - Add `"alter_token"` and `"asksage_token"` to debug-log sanitization exclusion list

Companion PR: #55 (AskSageClient implementation)
