### PR TITLE
fix: LocalClient auto-detects OpenAI-compat servers (LM Studio, vLLM) via /v1 in URL

### DIFF
--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -136,7 +136,11 @@ class LocalClient(BaseAIClient):
         if self._openai_compat:
             # OpenAI-compatible mode: LM Studio, vLLM, and similar servers
             # Use POST /v1/chat/completions with messages array
-            endpoint = self.url if self.url.endswith("/chat/completions") else self.url + "/chat/completions"
+            endpoint = (
+                self.url
+                if self.url.endswith("/chat/completions")
+                else self.url + "/chat/completions"
+            )
             payload = {
                 "messages": messages,
                 "stream": False,
@@ -148,7 +152,9 @@ class LocalClient(BaseAIClient):
                 endpoint,
                 self.model or "[none]",
             )
-            _LOGGER.debug("Local API request payload: %s", json.dumps(payload, indent=2))
+            _LOGGER.debug(
+                "Local API request payload: %s", json.dumps(payload, indent=2)
+            )
         else:
             # Ollama-native mode: POST /api/generate with flat prompt string
             endpoint = self.url
@@ -171,7 +177,9 @@ class LocalClient(BaseAIClient):
             if self.model:
                 payload["model"] = self.model
 
-            _LOGGER.debug("Local API request payload: %s", json.dumps(payload, indent=2))
+            _LOGGER.debug(
+                "Local API request payload: %s", json.dumps(payload, indent=2)
+            )
 
             if "model" not in payload or not payload["model"]:
                 _LOGGER.warning(

--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -115,8 +115,10 @@ class BaseAIClient:
 
 class LocalClient(BaseAIClient):
     def __init__(self, url, model=""):
-        self.url = url
+        self.url = url.rstrip("/")
         self.model = model
+        # Auto-detect OpenAI-compatible servers (LM Studio, vLLM, etc.) by /v1 in URL
+        self._openai_compat = "/v1" in self.url
 
     async def get_response(self, messages, **kwargs):
         _LOGGER.debug(
@@ -131,51 +133,59 @@ class LocalClient(BaseAIClient):
             )
         headers = {"Content-Type": "application/json"}
 
-        # Format user prompt from messages
-        prompt = ""
-        for message in messages:
-            role = message.get("role", "")
-            content = message.get("content", "")
-
-            # Simple formatting: prefixing each message with its role
-            if role == "system":
-                prompt += f"System: {content}\n\n"
-            elif role == "user":
-                prompt += f"User: {content}\n\n"
-            elif role == "assistant":
-                prompt += f"Assistant: {content}\n\n"
-
-        # Add final prompt prefix for the assistant's response
-        prompt += "Assistant: "
-
-        # Build a generic payload that works with most local API servers
-        payload = {
-            "prompt": prompt,
-            "stream": False,  # Disable streaming to get a single complete response
-            # max_tokens omitted - let local model use its default capacity
-        }
-
-        # Add model if specified
-        if self.model:
-            payload["model"] = self.model
-
-        # Note: Payloads don't contain auth tokens (those are in headers), but may contain user prompts
-        _LOGGER.debug("Local API request payload: %s", json.dumps(payload, indent=2))
-
-        # Ollama-specific validation
-        if "model" not in payload or not payload["model"]:
-            _LOGGER.warning(
-                "Missing 'model' field in request to local API. This may cause issues with Ollama."
-            )
-        elif self.url and "ollama" in self.url.lower():
+        if self._openai_compat:
+            # OpenAI-compatible mode: LM Studio, vLLM, and similar servers
+            # Use POST /v1/chat/completions with messages array
+            endpoint = self.url if self.url.endswith("/chat/completions") else self.url + "/chat/completions"
+            payload = {
+                "messages": messages,
+                "stream": False,
+            }
+            if self.model:
+                payload["model"] = self.model
             _LOGGER.debug(
-                "Detected Ollama URL, ensuring model is specified: %s",
-                payload.get("model"),
+                "OpenAI-compat mode — POST %s with model: %s",
+                endpoint,
+                self.model or "[none]",
             )
+            _LOGGER.debug("Local API request payload: %s", json.dumps(payload, indent=2))
+        else:
+            # Ollama-native mode: POST /api/generate with flat prompt string
+            endpoint = self.url
+            prompt = ""
+            for message in messages:
+                role = message.get("role", "")
+                content = message.get("content", "")
+                if role == "system":
+                    prompt += f"System: {content}\n\n"
+                elif role == "user":
+                    prompt += f"User: {content}\n\n"
+                elif role == "assistant":
+                    prompt += f"Assistant: {content}\n\n"
+            prompt += "Assistant: "
+
+            payload = {
+                "prompt": prompt,
+                "stream": False,
+            }
+            if self.model:
+                payload["model"] = self.model
+
+            _LOGGER.debug("Local API request payload: %s", json.dumps(payload, indent=2))
+
+            if "model" not in payload or not payload["model"]:
+                _LOGGER.warning(
+                    "Missing 'model' field in request to local API. This may cause issues with Ollama."
+                )
+            elif self.url and "ollama" in self.url.lower():
+                _LOGGER.debug(
+                    "Detected Ollama URL, ensuring model is specified: %s",
+                    payload.get("model"),
+                )
 
         async with aiohttp.ClientSession() as session:
             async with session.post(
-                self.url,
+                endpoint,
                 headers=headers,
                 json=payload,
                 timeout=aiohttp.ClientTimeout(total=300),


### PR DESCRIPTION
## Summary

`LocalClient` currently sends an Ollama-native `POST /api/generate` request with a flat `prompt` string to _any_ configured URL. Servers that expose an OpenAI-compatible `/v1` API (LM Studio, vLLM, Jan, etc.) reject this with:

```
Unexpected endpoint or method. (POST /v1)
```

This silently falls back to whatever other provider is configured, so the user sees no error — just wrong-model responses.

Fixes #57.

---

## Root Cause

`LocalClient.get_response` always builds:

```python
payload = {"prompt": prompt, "stream": False}
```

and `POST`s it to `self.url` verbatim. OpenAI-compat servers expect `POST /v1/chat/completions` with a `messages` array.

---

## Fix

Auto-detect the server type in `__init__` by checking for `/v1` in the URL:

```python
self._openai_compat = "/v1" in self.url
```

Then branch in `get_response`:

| Mode | Endpoint | Payload |
|------|----------|---------|
| `_openai_compat = True` | `{url}/chat/completions` | `{"messages": [...], "model": "...", "stream": false}` |
| `_openai_compat = False` | `{url}` (unchanged) | `{"prompt": "...", "model": "...", "stream": false}` |

Also strips trailing slashes from the configured URL to prevent double-slash endpoints.

---

## Testing

Verified manually with LM Studio at `http://192.168.0.57:1234/v1` — requests now correctly hit `POST /v1/chat/completions` and return valid responses. Ollama behaviour is unchanged (Ollama URLs do not contain `/v1` by default).

---

## Related

- Issue: #57 — bug: LocalClient sends Ollama-native POST to LM Studio/OpenAI-compat servers
- Fork: https://github.com/JLay2026/ai_agent_ha/tree/fix/local-client-openai-compat
