### PR TITLE
Fix Local model custom name storage

### DIFF
--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -2599,46 +2599,46 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
 
             provider_config = {
                 "openai": {
-                    "token_key": "openai_token",
+                    "token_key": "openai_token",  # nosec B105 - dict-key field name, not a credential value (false positive)
                     "model": models_config.get("openai", "gpt-3.5-turbo"),
                     "client_class": OpenAIClient,
                 },
                 "gemini": {
-                    "token_key": "gemini_token",
+                    "token_key": "gemini_token",  # nosec B105 - dict-key field name, not a credential value (false positive)
                     "model": models_config.get("gemini", "gemini-1.5-flash"),
                     "client_class": GeminiClient,
                 },
                 "openrouter": {
-                    "token_key": "openrouter_token",
+                    "token_key": "openrouter_token",  # nosec B105 - dict-key field name, not a credential value (false positive)
                     "model": models_config.get("openrouter", "openai/gpt-4o"),
                     "client_class": OpenRouterClient,
                 },
                 "llama": {
-                    "token_key": "llama_token",
+                    "token_key": "llama_token",  # nosec B105 - dict-key field name, not a credential value (false positive)
                     "model": models_config.get(
                         "llama", "Llama-4-Maverick-17B-128E-Instruct-FP8"
                     ),
                     "client_class": LlamaClient,
                 },
                 "anthropic": {
-                    "token_key": "anthropic_token",
+                    "token_key": "anthropic_token",  # nosec B105 - dict-key field name, not a credential value (false positive)
                     "model": models_config.get(
                         "anthropic", "claude-sonnet-4-5-20250929"
                     ),
                     "client_class": AnthropicClient,
                 },
                 "alter": {
-                    "token_key": "alter_token",
+                    "token_key": "alter_token",  # nosec B105 - dict-key field name, not a credential value (false positive)
                     "model": models_config.get("alter", ""),
                     "client_class": AlterClient,
                 },
                 "zai": {
-                    "token_key": "zai_token",
+                    "token_key": "zai_token",  # nosec B105 - dict-key field name, not a credential value (false positive)
                     "model": models_config.get("zai", ""),
                     "client_class": ZaiClient,
                 },
                 "local": {
-                    "token_key": "local_url",
+                    "token_key": "local_url",  # nosec B105 - dict-key field name, not a credential value (false positive)
                     "model": models_config.get("local", ""),
                     "client_class": LocalClient,
                 },

--- a/custom_components/ai_agent_ha/config_flow.py
+++ b/custom_components/ai_agent_ha/config_flow.py
@@ -412,6 +412,32 @@ class AiAgentHaOptionsFlowHandler(config_entries.OptionsFlow):
         # Use current token if provider hasn't changed, otherwise empty
         display_token = current_token if provider == current_provider else ""
 
+        # Determine if current model is a custom model (not in available models list)
+        # and prepare model dropdown and custom model field defaults
+        model_options = available_models
+        if "Custom..." not in model_options:
+            model_options = model_options + ["Custom..."]
+
+        # Check if current_model is a custom model (not in the available models)
+        # Remove "Custom..." from the check since it's the selector option, not a real model
+        available_models_without_custom = [
+            m for m in available_models if m != "Custom..."
+        ]
+        is_custom_model = (
+            current_model
+            and current_model not in available_models_without_custom
+            and current_model != "Custom..."
+        )
+
+        if is_custom_model:
+            # Current model is a custom model - show "Custom..." in dropdown and populate custom field
+            model_default = "Custom..."
+            custom_model_default = current_model
+        else:
+            # Current model is a standard model or empty
+            model_default = current_model if current_model else "Custom..."
+            custom_model_default = ""
+
         if user_input is not None:
             try:
                 token_value = user_input.get(token_field)
@@ -471,6 +497,9 @@ class AiAgentHaOptionsFlowHandler(config_entries.OptionsFlow):
         if provider == "zai":
             current_endpoint = self.config_entry.data.get("zai_endpoint", "general")
             model_options = AVAILABLE_MODELS.get("zai", ["glm-4.7"])
+            # Ensure "Custom..." is in model options
+            if "Custom..." not in model_options:
+                model_options = model_options + ["Custom..."]
             schema_dict = {
                 vol.Required(token_field, default=display_token): TextSelector(
                     TextSelectorConfig(type="password")
@@ -483,12 +512,12 @@ class AiAgentHaOptionsFlowHandler(config_entries.OptionsFlow):
                         ]
                     )
                 ),
-                vol.Optional("model", default=current_model): SelectSelector(
+                vol.Optional("model", default=model_default): SelectSelector(
                     SelectSelectorConfig(options=model_options)
                 ),
-                vol.Optional("custom_model"): TextSelector(
-                    TextSelectorConfig(type="text")
-                ),
+                vol.Optional(
+                    "custom_model", default=custom_model_default
+                ): TextSelector(TextSelectorConfig(type="text")),
             }
 
             return self.async_show_form(
@@ -513,13 +542,14 @@ class AiAgentHaOptionsFlowHandler(config_entries.OptionsFlow):
 
             # Add model selection
             model_options = AVAILABLE_MODELS.get("local", ["Custom..."])
-            schema_dict[
-                vol.Optional(
-                    "model", default=current_model if current_model else "Custom..."
-                )
-            ] = SelectSelector(SelectSelectorConfig(options=model_options))
-            schema_dict[vol.Optional("custom_model")] = TextSelector(
-                TextSelectorConfig(type="text")
+            # Ensure "Custom..." is in model options
+            if "Custom..." not in model_options:
+                model_options = model_options + ["Custom..."]
+            schema_dict[vol.Optional("model", default=model_default)] = SelectSelector(
+                SelectSelectorConfig(options=model_options)
+            )
+            schema_dict[vol.Optional("custom_model", default=custom_model_default)] = (
+                TextSelector(TextSelectorConfig(type="text"))
             )
 
             return self.async_show_form(
@@ -541,16 +571,12 @@ class AiAgentHaOptionsFlowHandler(config_entries.OptionsFlow):
 
         # Add model selection if available
         if available_models:
-            # Add predefined models + custom option (avoid duplicating "Custom...")
-            if "Custom..." in available_models:
-                model_options = available_models
-            else:
-                model_options = available_models + ["Custom..."]
-            schema_dict[vol.Optional("model", default=current_model)] = SelectSelector(
+            # model_options already has "Custom..." added above
+            schema_dict[vol.Optional("model", default=model_default)] = SelectSelector(
                 SelectSelectorConfig(options=model_options)
             )
-            schema_dict[vol.Optional("custom_model")] = TextSelector(
-                TextSelectorConfig(type="text")
+            schema_dict[vol.Optional("custom_model", default=custom_model_default)] = (
+                TextSelector(TextSelectorConfig(type="text"))
             )
 
         return self.async_show_form(

--- a/custom_components/ai_agent_ha/config_flow.py
+++ b/custom_components/ai_agent_ha/config_flow.py
@@ -314,7 +314,7 @@ class AiAgentHaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
                 data_schema=vol.Schema(schema_dict),
                 errors=errors,
                 description_placeholders={
-                    "token_label": "Local API URL",
+                    "token_label": "Local API URL",  # nosec B105 - UI label string shown next to the URL field, not a credential
                     "provider": PROVIDERS[provider],
                 },
             )
@@ -557,7 +557,7 @@ class AiAgentHaOptionsFlowHandler(config_entries.OptionsFlow):
                 data_schema=vol.Schema(schema_dict),
                 errors=errors,
                 description_placeholders={
-                    "token_label": "Local API URL",
+                    "token_label": "Local API URL",  # nosec B105 - UI label string shown next to the URL field, not a credential
                     "provider": PROVIDERS[provider],
                 },
             )


### PR DESCRIPTION
## Summary

Fixes bug where Local model settings do not store Custom Model name correctly.

## Problem

When configuring a Local Model provider (e.g., Ollama), users can select "Custom" from the Model dropdown and enter a custom model name in the "Custom Model" field. However, after saving and reopening the configuration, the custom model name appeared in the "Model" box instead of the "Custom Model" box, and the "Custom Model" box was blank.

This indicated that the custom model name was being saved to the wrong field in the configuration data.

## Solution

- Detect if current model is a custom model (not in available models list)
- When custom model detected, show "Custom..." in model dropdown and populate the custom_model field with the saved custom model name
- When standard model, use the model name as dropdown default and clear custom field
- Ensure "Custom..." option is available in all model dropdowns (OpenAI, ZAI, Local, and generic providers)
- Add default values for custom_model field based on whether current model is custom or standard

## Changes

Modified :
- Added logic to detect custom models by checking if current_model is not in available models
- Set appropriate defaults for model dropdown and custom_model field
- Ensure "Custom..." option is added to all model dropdowns
- Updated schema definitions to use calculated defaults

## Testing

- Tested that entering a custom model name and saving stores it correctly
- Verified that reopening configuration shows Model dropdown as "Custom..." and Custom Model field populated with saved name
- Confirmed preset models still work correctly
- Tested switching between Custom and preset models