### PR TITLE
Fix sys.modules leak that broke 4 tests in CI

### DIFF
--- a/tests/test_ai_agent_ha/test_config_flow.py
+++ b/tests/test_ai_agent_ha/test_config_flow.py
@@ -28,15 +28,29 @@ def _import_config_flow_directly():
         os.path.dirname(__file__), "..", "..", "custom_components", "ai_agent_ha", "config_flow.py"
     )
     config_flow_path = os.path.abspath(config_flow_path)
-    
+
     spec = importlib.util.spec_from_file_location("config_flow", config_flow_path)
     config_flow_module = importlib.util.module_from_spec(spec)
-    
-    # Mock dependencies before executing
-    sys.modules["homeassistant.helpers.config_validation"] = MagicMock()
-    sys.modules["voluptuous"] = MagicMock()
-    
-    spec.loader.exec_module(config_flow_module)
+
+    # Mocking voluptuous globally would leak into other tests and break any
+    # later import of real Home Assistant components (vol.Required would
+    # resolve to a MagicMock). Restore sys.modules after exec_module.
+    _SENTINEL = object()
+    mocked = {
+        "homeassistant.helpers.config_validation": MagicMock(),
+        "voluptuous": MagicMock(),
+    }
+    originals = {name: sys.modules.get(name, _SENTINEL) for name in mocked}
+    sys.modules.update(mocked)
+
+    try:
+        spec.loader.exec_module(config_flow_module)
+    finally:
+        for name, original in originals.items():
+            if original is _SENTINEL:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
     return config_flow_module
 
 

--- a/tests/test_ai_agent_ha/test_config_flow_comprehensive.py
+++ b/tests/test_ai_agent_ha/test_config_flow_comprehensive.py
@@ -16,15 +16,29 @@ def _import_config_flow_directly():
         os.path.dirname(__file__), "..", "..", "custom_components", "ai_agent_ha", "config_flow.py"
     )
     config_flow_path = os.path.abspath(config_flow_path)
-    
+
     spec = importlib.util.spec_from_file_location("config_flow", config_flow_path)
     config_flow_module = importlib.util.module_from_spec(spec)
-    
-    # Mock dependencies before executing
-    sys.modules["homeassistant.helpers.config_validation"] = MagicMock()
-    sys.modules["voluptuous"] = MagicMock()
-    
-    spec.loader.exec_module(config_flow_module)
+
+    # Mocking voluptuous globally would leak into other tests and break any
+    # later import of real Home Assistant components (vol.Required would
+    # resolve to a MagicMock). Restore sys.modules after exec_module.
+    _SENTINEL = object()
+    mocked = {
+        "homeassistant.helpers.config_validation": MagicMock(),
+        "voluptuous": MagicMock(),
+    }
+    originals = {name: sys.modules.get(name, _SENTINEL) for name in mocked}
+    sys.modules.update(mocked)
+
+    try:
+        spec.loader.exec_module(config_flow_module)
+    finally:
+        for name, original in originals.items():
+            if original is _SENTINEL:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
     return config_flow_module
 
 


### PR DESCRIPTION
## Summary
- The `Test` workflow has been red on `main` since the Home Assistant upstream version bumped (~April). 4 tests fail with `KeyError: 'type'` inside `homeassistant/components/websocket_api/decorators.py:142`.
- Root cause: `_import_config_flow_directly()` in `test_config_flow.py` and `test_config_flow_comprehensive.py` did `sys.modules["voluptuous"] = MagicMock()` without restoring. Once either file ran, every later test that imported real HA modules (lovelace, recorder, system_health) crashed at module-load time, because `@websocket_api.websocket_command({vol.Required("type"): ...})` saw a `MagicMock` key instead of a real voluptuous marker.
- Fix: save originals before patching and restore them in a `try/finally` so the mocks are scoped to the `config_flow` import only.

## Failing tests now passing
- `tests/test_ai_agent_ha/test_dashboard_integration.py::TestDashboardManagement::test_get_dashboards`
- `tests/test_ai_agent_ha/test_dashboard_integration.py::TestDashboardManagement::test_get_dashboard_config`
- `tests/test_ai_agent_ha/test_entity_data_integration.py::TestEntityDataRetrieval::test_get_history`
- `tests/test_ai_agent_ha/test_entity_data_integration.py::TestEntityDataRetrieval::test_get_statistics`

## Test plan
- [x] `pytest tests/` locally: was `4 failed, 87 passed` → now `91 passed, 12 skipped, 0 failed`
- [x] Verified the originally failing tests still pass in isolation (they always did — they only failed when polluted by the config_flow tests running first in alphabetical order)
- [ ] Wait for CI to confirm the `Test` and `Python Tests` workflows go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)