### PR TITLE
Fix OpenAI-Compatible auth + OpenAI custom Base URL routing (#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12] - 2026-05-27
+
+### Fixed
+- **OpenAI-Compatible provider was missing the API key field** ([#70](https://github.com/sbenodiz/ai_agent_ha/issues/70))
+  - The runtime read `openai_compatible_api_key` from config, but the config flow never
+    collected it, so the `Authorization: Bearer ...` header was never sent. Authenticated
+    gateways (Open WebUI, LiteLLM, hosted vLLM) returned 401 even when the same key
+    worked in the gateway's own UI.
+  - Added an optional API key field to both the initial config and the options/edit flow.
+- **OpenAI provider with a custom Base URL hit `/responses`** ([#70](https://github.com/sbenodiz/ai_agent_ha/issues/70))
+  - Third-party "OpenAI-compatible" servers implement `/chat/completions`, not OpenAI's
+    newer Responses API. The OpenAI client now routes to `/chat/completions` when the
+    Base URL is not `api.openai.com`, and keeps the Responses API for real OpenAI.
+
+## [1.11] (and earlier accumulated changes)
+
 ### Fixed
 - **CRITICAL**: Fixed Anthropic API system prompt being overwritten by data payloads
   - Data responses now correctly use "user" role instead of "system" role

--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -786,12 +786,21 @@ class OpenAIClient(BaseAIClient):
     def __init__(self, token, model="gpt-4.1-mini", base_url=None):
         self.token = token
         self.model = model
-        # Use custom base_url if provided; otherwise default to official OpenAI endpoint
+        # Default endpoint is OpenAI's Responses API. If the user has pointed Base URL
+        # at a third-party "OpenAI-compatible" gateway (Open WebUI, LM Studio, vLLM,
+        # LiteLLM, ...), those servers only implement /chat/completions, so switch
+        # to Chat Completions when the base URL is not api.openai.com.
         if base_url and base_url.strip():
             base = base_url.strip().rstrip("/")
-            self.api_url = f"{base}/responses"
+            if "api.openai.com" in base:
+                self.api_url = f"{base}/responses"
+                self.use_chat_completions = False
+            else:
+                self.api_url = f"{base}/chat/completions"
+                self.use_chat_completions = True
         else:
             self.api_url = "https://api.openai.com/v1/responses"
+            self.use_chat_completions = False
 
     def _is_restricted_model(self):
         """Check if the model has restricted parameters (no temperature, top_p, etc.)."""
@@ -813,28 +822,33 @@ class OpenAIClient(BaseAIClient):
             "Content-Type": "application/json",
         }
 
-        # Build input string from messages for the Responses API
-        # Preserve system instructions and conversation history in a simple format
-        parts = []
-        for msg in messages:
-            role = (msg.get("role") or "user").lower()
-            content = msg.get("content") or ""
-            if role == "system":
-                parts.append(f"System: {content}")
-            elif role == "user":
-                parts.append(f"User: {content}")
-            elif role == "assistant":
-                parts.append(f"Assistant: {content}")
-            else:
-                parts.append(f"{role.capitalize()}: {content}")
-
-        input_text = "\n\n".join(parts)
-
-        # Build payload for /v1/responses
-        payload = {
-            "model": self.model,
-            "input": input_text,
-        }
+        if self.use_chat_completions:
+            # Chat Completions: forward messages as-is.
+            payload = {
+                "model": self.model,
+                "messages": messages,
+            }
+            if not self._is_restricted_model():
+                payload["temperature"] = 0.7
+                payload["top_p"] = 0.9
+        else:
+            # Responses API: flatten messages into a single input string.
+            parts = []
+            for msg in messages:
+                role = (msg.get("role") or "user").lower()
+                content = msg.get("content") or ""
+                if role == "system":
+                    parts.append(f"System: {content}")
+                elif role == "user":
+                    parts.append(f"User: {content}")
+                elif role == "assistant":
+                    parts.append(f"Assistant: {content}")
+                else:
+                    parts.append(f"{role.capitalize()}: {content}")
+            payload = {
+                "model": self.model,
+                "input": "\n\n".join(parts),
+            }
 
         _LOGGER.debug("OpenAI request payload: %s", json.dumps(payload, indent=2))
 
@@ -860,6 +874,17 @@ class OpenAIClient(BaseAIClient):
                     raise Exception(
                         f"Invalid JSON response from OpenAI: {response_text[:200]}"
                     )
+
+                if self.use_chat_completions:
+                    # Chat Completions response shape
+                    choices = data.get("choices", [])
+                    if choices and "message" in choices[0]:
+                        return choices[0]["message"].get("content", "") or ""
+                    _LOGGER.warning("OpenAI response missing expected structure")
+                    _LOGGER.debug(
+                        "Full OpenAI response: %s", json.dumps(data, indent=2)
+                    )
+                    return str(data)
 
                 # Extract text from OpenAI Responses API
                 # Primary field: output_text

--- a/custom_components/ai_agent_ha/config_flow.py
+++ b/custom_components/ai_agent_ha/config_flow.py
@@ -253,12 +253,16 @@ class AiAgentHaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
                     # For OpenAI, move to next step to select model from dynamic list
                     return await self.async_step_configure_openai_models()
 
-                # For OpenAI-Compatible, store Base URL and move to model selection
+                # For OpenAI-Compatible, store Base URL + optional API key, then move on
                 if provider == "openai_compatible":
                     base_url = (
                         user_input.get(CONF_OPENAI_COMPATIBLE_URL) or ""
                     ).strip()
                     self.config_data[CONF_OPENAI_COMPATIBLE_URL] = base_url
+                    api_key = (
+                        user_input.get("openai_compatible_api_key") or ""
+                    ).strip()
+                    self.config_data["openai_compatible_api_key"] = api_key
                     # Move to next step to select model from dynamic list
                     return await self.async_step_configure_openai_compatible_models()
 
@@ -364,11 +368,15 @@ class AiAgentHaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
             )
 
         if provider == "openai_compatible":
-            # For openai_compatible provider, we need base URL and optional model name
-            # We'll fetch models dynamically in the next step if the endpoint supports it
+            # For openai_compatible provider, we need base URL + optional API key.
+            # Many local endpoints (LM Studio, vLLM) need no key; gateways like
+            # Open WebUI or LiteLLM require one. Models are fetched in the next step.
             schema_dict = {
                 vol.Required(CONF_OPENAI_COMPATIBLE_URL): TextSelector(
                     TextSelectorConfig(type="text")
+                ),
+                vol.Optional("openai_compatible_api_key", default=""): TextSelector(
+                    TextSelectorConfig(type="password")
                 ),
             }
 
@@ -672,6 +680,12 @@ class AiAgentHaOptionsFlowHandler(config_entries.OptionsFlow):
                             base_url or "https://api.openai.com/v1"
                         )
 
+                    # For OpenAI-Compatible, update the optional API key
+                    if provider == "openai_compatible":
+                        updated_data["openai_compatible_api_key"] = (
+                            user_input.get("openai_compatible_api_key") or ""
+                        ).strip()
+
                     # Initialize models dict if it doesn't exist
                     if "models" not in updated_data:
                         updated_data["models"] = {}
@@ -782,13 +796,15 @@ class AiAgentHaOptionsFlowHandler(config_entries.OptionsFlow):
             )
 
         if provider == "openai_compatible":
-            # For openai_compatible provider, we need URL and optional model name
+            # For openai_compatible provider, we need URL + optional API key + model
             current_url = self.config_entry.data.get(CONF_OPENAI_COMPATIBLE_URL, "")
+            current_api_key = (
+                self.config_entry.data.get("openai_compatible_api_key") or ""
+            )
 
             # Fetch available models dynamically if the endpoint supports it
-            api_key = self.config_entry.data.get("openai_compatible_api_key") or ""
             model_list = await fetch_openai_compatible_models(
-                current_url, api_key or None
+                current_url, current_api_key or None
             )
 
             # Ensure "Custom..." is always available
@@ -799,6 +815,9 @@ class AiAgentHaOptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Required(
                     CONF_OPENAI_COMPATIBLE_URL, default=current_url
                 ): TextSelector(TextSelectorConfig(type="text")),
+                vol.Optional(
+                    "openai_compatible_api_key", default=current_api_key
+                ): TextSelector(TextSelectorConfig(type="password")),
             }
 
             # Add model selection with dynamic list

--- a/custom_components/ai_agent_ha/manifest.json
+++ b/custom_components/ai_agent_ha/manifest.json
@@ -20,5 +20,5 @@
     "requirements": [
         "aiohttp>=3.8.0"
     ],
-    "version": "1.08"
+    "version": "1.12"
 }


### PR DESCRIPTION
## Summary

Fixes two related defects reported in #70 that prevented connecting the OpenAI‑Compatible provider (and the OpenAI provider with a custom Base URL) to third‑party gateways like Open WebUI / LiteLLM / hosted vLLM:

- **Bug 1 — OpenAI‑Compatible had no API key field.** The runtime read `openai_compatible_api_key` from config, but the config flow never collected it. The `Authorization: Bearer ...` header was therefore never sent and auth‑required gateways returned 401 even when the same key worked in the gateway's own UI. Added an optional API key field to both the initial config and the options/edit flow, and persisted it in both paths.
- **Bug 2 — OpenAI provider with custom Base URL hit `/responses`.** Third‑party "OpenAI‑compatible" servers implement `/chat/completions`, not OpenAI's newer Responses API. The OpenAI client now routes to `/chat/completions` (with Chat Completions request/response format) when the Base URL is not `api.openai.com`, and keeps the Responses API path for real OpenAI — no behavior change there.

Bumps `manifest.json` to `1.12`.

## Verification

Both bugs were reproduced on the wire against a local mock server using the v1.11 code, then re-tested against the patched v1.12 code:

| Test | v1.11 | v1.12 |
|---|---|---|
| `OpenAIClient(token, base_url="http://my-server/v1")` | POSTs to `/v1/responses` | POSTs to `/v1/chat/completions` ✅ |
| `OpenAIClient(token)` (default) | POSTs to `/v1/responses` | POSTs to `/v1/responses` (unchanged) ✅ |
| `OpenaiCompatibleClient(url, model, api_key=None)` | No `Authorization` header (and there was no UI to set one) | Now has an API key field in config flow ✅ |

## Test plan

- [ ] HACS update to v1.12, reconfigure the OpenAI‑Compatible provider against an auth‑required endpoint (Open WebUI), confirm 200s.
- [ ] Reconfigure the OpenAI provider with default Base URL (api.openai.com) and a real OpenAI key, confirm Responses API still works.
- [ ] Reconfigure the OpenAI provider with a non‑OpenAI Base URL, confirm it now hits `/chat/completions` on that server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)