### PR TITLE
Add regression tests for #70 fixes (OpenAI-Compat auth + Base URL routing)

### DIFF
--- a/tests/test_ai_agent_ha/test_agent_clients.py
+++ b/tests/test_ai_agent_ha/test_agent_clients.py
@@ -121,13 +121,68 @@ class TestOpenAIClient:
         """Test OpenAIClient with invalid token."""
         try:
             from custom_components.ai_agent_ha.agent import OpenAIClient
-            
+
             client = OpenAIClient("invalid-token", "gpt-3.5-turbo")
-            
+
             with pytest.raises(Exception) as exc_info:
                 await client.get_response([{"role": "user", "content": "test"}])
             assert "Invalid OpenAI API key format" in str(exc_info.value)
-            
+
+        except ImportError:
+            pytest.skip("OpenAIClient not available")
+
+    def test_openai_client_default_uses_responses_api(self):
+        """Regression: default OpenAIClient hits OpenAI's Responses API.
+
+        Locks in v1.12 behavior (issue #70). Real OpenAI users must keep
+        the /responses endpoint.
+        """
+        try:
+            from custom_components.ai_agent_ha.agent import OpenAIClient
+
+            client = OpenAIClient("sk-test", "gpt-4.1-mini")
+            assert client.api_url == "https://api.openai.com/v1/responses"
+            assert client.use_chat_completions is False
+        except ImportError:
+            pytest.skip("OpenAIClient not available")
+
+    def test_openai_client_official_base_url_uses_responses_api(self):
+        """Regression: explicit api.openai.com base_url still uses Responses API."""
+        try:
+            from custom_components.ai_agent_ha.agent import OpenAIClient
+
+            client = OpenAIClient(
+                "sk-test", "gpt-4.1-mini", base_url="https://api.openai.com/v1"
+            )
+            assert client.api_url == "https://api.openai.com/v1/responses"
+            assert client.use_chat_completions is False
+        except ImportError:
+            pytest.skip("OpenAIClient not available")
+
+    def test_openai_client_custom_base_url_uses_chat_completions(self):
+        """Regression for issue #70 Bug 2: custom Base URL must route to /chat/completions.
+
+        Third-party OpenAI-compatible servers (Open WebUI, LM Studio, vLLM, LiteLLM)
+        do not implement the Responses API. If this test fails because someone
+        reverted to /responses, users with custom Base URLs will get 401 / 404.
+        """
+        try:
+            from custom_components.ai_agent_ha.agent import OpenAIClient
+
+            client = OpenAIClient(
+                "sk-test", "my-model", base_url="https://my-gateway.example.com/v1"
+            )
+            assert client.api_url == "https://my-gateway.example.com/v1/chat/completions"
+            assert client.use_chat_completions is True
+
+            # Trailing slash must be stripped before /chat/completions is appended.
+            client_ts = OpenAIClient(
+                "sk-test", "my-model", base_url="https://my-gateway.example.com/v1/"
+            )
+            assert (
+                client_ts.api_url
+                == "https://my-gateway.example.com/v1/chat/completions"
+            )
         except ImportError:
             pytest.skip("OpenAIClient not available")
 

--- a/tests/test_ai_agent_ha/test_config_flow.py
+++ b/tests/test_ai_agent_ha/test_config_flow.py
@@ -128,11 +128,50 @@ class TestConfigFlow:
         try:
             config_flow_module = _import_config_flow_directly()
             flow_class = config_flow_module.AiAgentHaConfigFlow
-            
+
             # Test that we can instantiate the class (basic smoke test)
             flow = flow_class()
             assert flow is not None
             assert flow.VERSION == 1
-            
+
         except Exception as e:
             pytest.skip(f"Config flow schema test failed: {e}")
+
+    def test_openai_compatible_api_key_field_present(self):
+        """Regression for issue #70 Bug 1: openai_compatible must expose an API key field.
+
+        In v1.11 the runtime read openai_compatible_api_key from config but the
+        config flow never collected it, so the Authorization header was never sent
+        and authenticated gateways returned 401. This test guards against that
+        regression by checking the source of config_flow.py for:
+          - the field appearing as a vol.Optional in BOTH the create and options forms
+          - the field being persisted in BOTH save paths
+        """
+        config_flow_path = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "..",
+                "..",
+                "custom_components",
+                "ai_agent_ha",
+                "config_flow.py",
+            )
+        )
+        with open(config_flow_path, encoding="utf-8") as f:
+            src = f.read()
+
+        # The field must appear as an Optional schema entry at least twice
+        # (initial create flow + options/edit flow).
+        field_decls = src.count('"openai_compatible_api_key"')
+        assert field_decls >= 4, (
+            f"openai_compatible_api_key referenced only {field_decls}× in "
+            f"config_flow.py; expected >= 4 (2 schema fields + 2 save paths)"
+        )
+
+        # And it must be persisted into the config in both paths.
+        assert 'self.config_data["openai_compatible_api_key"]' in src, (
+            "openai_compatible_api_key not saved in initial config flow"
+        )
+        assert 'updated_data["openai_compatible_api_key"]' in src, (
+            "openai_compatible_api_key not saved in options/edit flow"
+        )


### PR DESCRIPTION
## Summary

Adds tests that lock in the two fixes shipped in v1.12 (PR #73) so a future refactor can't silently regress them.

- `TestOpenAIClient` — three URL‑construction tests:
  - Default (no `base_url`) keeps `/responses` (Responses API).
  - Explicit `https://api.openai.com/v1` base URL keeps `/responses`.
  - Non‑OpenAI base URL routes to `/chat/completions` and flips `use_chat_completions` to True (incl. trailing‑slash handling).
- `TestConfigFlow` — source‑level guard asserting that `openai_compatible_api_key` appears as a schema field in **both** the initial create flow and the options/edit flow, and is persisted in **both** save paths. v1.11 had reads but zero writes — exactly the bug this test now catches.

## Test plan

- [x] Source‑level config‑flow test passes locally (`pytest -xvs ...test_openai_compatible_api_key_field_present` → 1 passed)
- [x] OpenAIClient tests skip locally (no HA installed) — identical to the existing tests' pattern in this file
- [ ] CI runs all of them green on Python 3.12 with HA installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)