### PR TITLE
Fix OpenAI Responses API returning a list (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13] - 2026-06-01
+
+### Fixed
+- **OpenAI provider crashed with `'list' object has no attribute 'strip'`** ([#75](https://github.com/sbenodiz/ai_agent_ha/issues/75))
+  - The OpenAI Responses API (`/v1/responses`, the default for the OpenAI provider)
+    returns the assistant text nested in `output[].content[].text`, and the raw HTTP
+    body has no top-level `output_text` (that field is an SDK-only convenience
+    property). The response parser fell through to a fallback that returned the
+    `content` **list** instead of a string, so the agent then called `.strip()` on a
+    list and failed on every retry — the sidebar showed "AI client error on attempt
+    1" repeated 10 times for any prompt.
+  - The parser now descends into `output[].content[]` and concatenates every
+    `output_text` block into a string, and correctly skips non-text items such as the
+    leading `reasoning` item emitted by o-series models.
+  - Added a defensive guard so any client that returns a non-string degrades
+    gracefully instead of exhausting all retries with an opaque `AttributeError`.
+
 ## [1.12] - 2026-05-27
 
 ### Fixed

--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -886,20 +886,41 @@ class OpenAIClient(BaseAIClient):
                     )
                     return str(data)
 
-                # Extract text from OpenAI Responses API
-                # Primary field: output_text
+                # Extract text from OpenAI Responses API.
+                # Primary field: output_text is an SDK-only convenience property
+                # and is normally absent from the raw HTTP body, so it is only a
+                # fast path when a gateway happens to include it as a string.
                 content = data.get("output_text")
-                if content:
+                if isinstance(content, str) and content:
                     return content
 
-                # Fallback: if response has 'output' list with text content
+                # Fallback: the Responses API returns
+                #   output: [ { type: "message", content: [ { type: "output_text",
+                #               text: "..." }, ... ] }, ... ]
+                # plus, for reasoning models, leading items (e.g. type "reasoning")
+                # that carry no text. Concatenate every output_text block we find.
+                # NOTE: item["content"] is a LIST here, so it must never be
+                # returned directly (that caused issue #75: 'list' object has no
+                # attribute 'strip').
                 output = data.get("output")
                 if isinstance(output, list):
+                    text_parts = []
                     for item in output:
-                        if isinstance(item, dict):
-                            tc = item.get("text") or item.get("content")
-                            if tc:
-                                return tc
+                        if not isinstance(item, dict):
+                            continue
+                        content_blocks = item.get("content")
+                        if isinstance(content_blocks, list):
+                            for block in content_blocks:
+                                if isinstance(block, dict) and isinstance(
+                                    block.get("text"), str
+                                ):
+                                    text_parts.append(block["text"])
+                        elif isinstance(content_blocks, str) and content_blocks:
+                            text_parts.append(content_blocks)
+                        elif isinstance(item.get("text"), str):
+                            text_parts.append(item["text"])
+                    if text_parts:
+                        return "".join(text_parts)
 
                 # Last resort: return full response as string
                 _LOGGER.warning("OpenAI response missing expected structure")
@@ -3870,6 +3891,21 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                     self._max_retries,
                 )
                 response = await self.ai_client.get_response(recent_messages)
+                # Every client is expected to return a string. Guard against a
+                # client handing back a non-string (e.g. a raw list/dict from an
+                # unexpected provider response shape) so the downstream string
+                # operations below don't crash with an unhelpful AttributeError
+                # and burn all retries (see issue #75).
+                if response is not None and not isinstance(response, str):
+                    _LOGGER.warning(
+                        "AI client returned non-string response of type %s; coercing to str",
+                        type(response).__name__,
+                    )
+                    response = (
+                        json.dumps(response)
+                        if isinstance(response, (list, dict))
+                        else str(response)
+                    )
                 _LOGGER.debug(
                     "AI client returned response of length: %d", len(response or "")
                 )

--- a/custom_components/ai_agent_ha/manifest.json
+++ b/custom_components/ai_agent_ha/manifest.json
@@ -20,5 +20,5 @@
     "requirements": [
         "aiohttp>=3.8.0"
     ],
-    "version": "1.12"
+    "version": "1.13"
 }

--- a/tests/test_ai_agent_ha/test_agent_clients.py
+++ b/tests/test_ai_agent_ha/test_agent_clients.py
@@ -11,6 +11,47 @@ import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 
+def _mock_aiohttp_session(response_text, status=200):
+    """Return a patch() for aiohttp.ClientSession that yields a fixed HTTP body.
+
+    Mocks the nested async context managers used by the clients:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(...) as resp:
+                await resp.text()
+    """
+
+    class _FakeResp:
+        def __init__(self):
+            self.status = status
+            self.headers = {}
+
+        async def text(self):
+            return response_text
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class _FakeSession:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def post(self, *args, **kwargs):
+            return _FakeResp()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    return patch(
+        "custom_components.ai_agent_ha.agent.aiohttp.ClientSession", _FakeSession
+    )
+
+
 class TestLocalOllamaClient:
     """Test Local Ollama AI client functionality."""
 
@@ -185,6 +226,103 @@ class TestOpenAIClient:
             )
         except ImportError:
             pytest.skip("OpenAIClient not available")
+
+    @pytest.mark.asyncio
+    async def test_openai_responses_api_returns_string_not_list(self):
+        """Regression for issue #75: 'list' object has no attribute 'strip'.
+
+        The raw /v1/responses body has NO top-level 'output_text' (that is an
+        SDK-only convenience property). The real text lives in
+        output[].content[].text, which is a LIST. The client must extract the
+        string, never return the content list (that caused _query_ai() to call
+        .strip() on a list and fail every attempt).
+        """
+        try:
+            from custom_components.ai_agent_ha.agent import OpenAIClient
+        except ImportError:
+            pytest.skip("OpenAIClient not available")
+
+        client = OpenAIClient("sk-test", "gpt-4o-mini")  # default -> /v1/responses
+        assert client.use_chat_completions is False
+
+        body = json.dumps(
+            {
+                "id": "resp_abc",
+                "object": "response",
+                "model": "gpt-4o-mini",
+                "status": "completed",
+                # Intentionally no "output_text" — matches the raw HTTP body.
+                "output": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": '{"request_type": "final_response", "response": "hi"}',
+                                "annotations": [],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+
+        with _mock_aiohttp_session(body):
+            result = await client.get_response([{"role": "user", "content": "hi"}])
+
+        assert isinstance(result, str), f"expected str, got {type(result).__name__}"
+        # The bug manifested as .strip() failing on a list; assert it works now.
+        assert result.strip() == (
+            '{"request_type": "final_response", "response": "hi"}'
+        )
+
+    @pytest.mark.asyncio
+    async def test_openai_responses_api_skips_reasoning_items(self):
+        """Reasoning models emit a leading 'reasoning' item with no text.
+
+        The client must skip it and still return the message text as a string.
+        """
+        try:
+            from custom_components.ai_agent_ha.agent import OpenAIClient
+        except ImportError:
+            pytest.skip("OpenAIClient not available")
+
+        client = OpenAIClient("sk-test", "o3-mini")
+
+        body = json.dumps(
+            {
+                "output": [
+                    {"type": "reasoning", "id": "rs_1", "summary": []},
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "answer text"}],
+                    },
+                ]
+            }
+        )
+
+        with _mock_aiohttp_session(body):
+            result = await client.get_response([{"role": "user", "content": "hi"}])
+
+        assert result == "answer text"
+
+    @pytest.mark.asyncio
+    async def test_openai_responses_api_uses_output_text_fast_path(self):
+        """If a gateway does include a string 'output_text', use it directly."""
+        try:
+            from custom_components.ai_agent_ha.agent import OpenAIClient
+        except ImportError:
+            pytest.skip("OpenAIClient not available")
+
+        client = OpenAIClient("sk-test", "gpt-4o-mini")
+        body = json.dumps({"output_text": "direct text", "output": []})
+
+        with _mock_aiohttp_session(body):
+            result = await client.get_response([{"role": "user", "content": "hi"}])
+
+        assert result == "direct text"
 
 
 class TestGeminiClient:


### PR DESCRIPTION
## Summary

Fixes #75 — OpenAI provider crashed with `'list' object has no attribute 'strip'` on every prompt (the sidebar showed *"AI client error on attempt 1"* repeated 10×).

## Root cause

The OpenAI **Responses API** (`/v1/responses`, the default endpoint for the OpenAI provider) nests the assistant text in `output[].content[].text`. The raw HTTP body has **no top-level `output_text`** — that field is an SDK-only convenience property, absent when calling the endpoint directly via `aiohttp`.

The parser at `agent.py` fell through to a fallback that did `item.get("text") or item.get("content")` and returned `content` — which is a **list** of content blocks. `OpenAIClient.get_response()` therefore returned a list, and `_query_ai()` then called `.strip()` on it → `AttributeError: 'list' object has no attribute 'strip'`, repeated across all `_max_retries`.

This was a regression introduced in `c159748` ("switch to Responses API").

## Fix

- Parse `output[].content[]` and concatenate every `output_text` block into a string; skip non-text items (e.g. the leading `reasoning` item o-series models emit).
- `output_text` is now only used as a fast path when it's actually a non-empty string.
- Defensive guard in `_query_ai`: any client returning a non-string is coerced (with a warning) instead of exhausting all retries with an opaque `AttributeError`.

## Tests

Added 3 regression tests in `test_agent_clients.py` (+ a reusable aiohttp mock helper):
- the Responses API message shape (asserts a `str`, not a list);
- the reasoning-item shape (o-series);
- the `output_text` fast path.

## Verification

Verified **live against the real OpenAI `/v1/responses` API** with `gpt-4o-mini`:
- the raw body has no `output_text` and `output[message].content` is a `list` (confirms the root cause);
- the **old** code returns a list → raises the exact reported error;
- the **patched** code returns a proper string.

Also ran `black`/`isort`/`flake8`/`mypy` locally on the changed files — all clean.

Ships as **v1.13** (manifest + CHANGELOG bumped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)