### PR TITLE
fix: pass openai_compatible_api_key when recreating client in process_query

### DIFF
--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -3079,11 +3079,15 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                     if selected_provider == "local_ollama":
                         # Support legacy local_url
                         url = token or config.get("local_url")
+                        self.ai_client = provider_settings["client_class"](
+                            url, provider_settings["model"]
+                        )
                     else:
                         url = token
-                    self.ai_client = provider_settings["client_class"](
-                        url, provider_settings["model"]
-                    )
+                        api_key = config.get("openai_compatible_api_key", "") or ""
+                        self.ai_client = provider_settings["client_class"](
+                            url, provider_settings["model"], api_key or None
+                        )
                     _LOGGER.debug(
                         f"Initialized {selected_provider} client with model {provider_settings['model']}"
                     )


### PR DESCRIPTION
## Problem

When using the **OpenAI-Compatible** provider with an authenticated gateway (e.g. [RouterAI](https://routerai.ru), Open WebUI, etc.), every chat/automation/dashboard request fails with:

```
Error processing AI response: Failed after 10 retries. Last error: OpenAI-compatible API error 401: {"error":"401 Unauthorized"}
```

## Root Cause

PR #73 added the API key field to the config flow and correctly initialized `OpenaiCompatibleClient` with the key in `async_setup_entry`. However, `process_query` **recreates** the client on every request and only passes `(url, model)` — the API key is dropped.

This means the saved `openai_compatible_api_key` is never sent at runtime, so authenticated gateways reject the request.

## Fix

In `process_query`, when `selected_provider == "openai_compatible"`, read `openai_compatible_api_key` from the config and pass it to `OpenaiCompatibleClient(url, model, api_key)`.

`local_ollama` path is left unchanged.

## Testing

- Reproduced with RouterAI (OpenAI-compatible API) using `deepseek/deepseek-v4-pro`.
- After patch: chat, automation, and dashboard requests authenticate successfully and return 200.

## Related

- Complements #73 / PR #73 (config-flow side of the same auth issue).
- Likely closes any remaining "401 Unauthorized" reports for OpenAI-Compatible providers.
