### PR TITLE
Fix Anthropic API error 400 on all queries with Claude models (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14] - 2026-06-06
+
+### Fixed
+- **Anthropic provider failed every query with `Anthropic API error 400` on larger installs** ([#80](https://github.com/sbenodiz/ai_agent_ha/issues/80))
+  - Root cause (confirmed live against the real Anthropic API): data requests such as
+    `get_entity_registry` dumped the *entire* install (800KB+ on ~2000+ entity setups)
+    into a single conversation message, exceeding Claude's 200k-token context window.
+    The API rejected it with `400 prompt is too long`, the integration discarded the
+    error body, retried the identical payload 10 times, and the oversized message
+    persisted in conversation history — making **every subsequent query fail too**.
+  - Data responses are now capped (~50k chars) with a truncation notice instructing
+    the model to request narrower data; the per-request message window is also capped
+    so multiple data messages can't stack past context or rate-limit budgets.
+  - Provider error bodies are now surfaced to the UI (e.g.
+    `Anthropic API error 400: prompt is too long: 205547 tokens > 200000 maximum`)
+    instead of a bare status code.
+  - Deterministic 4xx errors are no longer retried (previously 10 futile retries and
+    ~45s of backoff); HTTP 429 now honors the server's `retry-after` header so
+    per-minute token rate limit windows (e.g. Anthropic tier 1: 30k input tokens/min)
+    can actually reset between attempts.
+  - Failed queries are rolled back from conversation history so they can't poison
+    subsequent queries; the history window can no longer start mid-turn after slicing.
+  - Anthropic request timeout raised from 30s to 300s, matching every other provider.
+  - Agent loop allows up to 8 iterations (was 5) since capped data responses can
+    require additional narrower data requests.
+
 ## [1.13] - 2026-06-01
 
 ### Fixed

--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -1739,16 +1739,20 @@ class AiAgentHaAgent:
                     },
                     default=str,
                 )
-            _LOGGER.warning(
-                "Data response truncated from %d to %d items to fit context window",
-                len(data),
-                len(truncated),
-            )
-            return message
+            if len(message) <= self.MAX_DATA_MESSAGE_CHARS:
+                _LOGGER.warning(
+                    "Data response truncated from %d to %d items to fit context window",
+                    len(data),
+                    len(truncated),
+                )
+                return message
+            # A single item alone exceeds the cap - fall through to the
+            # hard-truncated preview below so the cap always holds.
 
-        # Non-list payloads: keep a prefix of the serialized form as a preview.
+        # Oversized non-list payloads (or a single oversized list item): keep
+        # a prefix of the serialized form as a preview.
         _LOGGER.warning(
-            "Oversized non-list data response truncated from %d chars", len(message)
+            "Oversized data response hard-truncated from %d chars", len(message)
         )
         preview = message[: self.MAX_DATA_MESSAGE_CHARS]
         result = json.dumps({"data_preview": preview, "truncated": True, "note": note})

--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -110,6 +110,28 @@ def sanitize_for_logging(data: Any, mask: str = "***REDACTED***") -> Any:
 
 
 # === AI Client Abstractions ===
+class NonRetryableAIError(Exception):
+    """Provider error that cannot succeed on retry (e.g. deterministic HTTP 4xx).
+
+    Raised for client errors like "prompt is too long" where re-sending the
+    identical payload is guaranteed to fail again (see issue #80). Rate
+    limiting (429) and request timeouts (408) stay retryable.
+    """
+
+
+class RateLimitedAIError(Exception):
+    """Provider rate limit (HTTP 429) with an optional server-suggested wait.
+
+    Carries the provider's retry-after hint so the retry loop can wait long
+    enough for a per-minute token window to reset instead of burning all
+    retries in a few seconds (see issue #80).
+    """
+
+    def __init__(self, message: str, retry_after: Optional[float] = None):
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
 class BaseAIClient:
     async def get_response(self, messages, **kwargs):
         raise NotImplementedError
@@ -1096,12 +1118,35 @@ class AnthropicClient(BaseAIClient):
                 self.api_url,
                 headers=headers,
                 json=payload,
-                timeout=aiohttp.ClientTimeout(total=30),
+                timeout=aiohttp.ClientTimeout(total=300),
             ) as resp:
                 if resp.status != 200:
                     error_text = await resp.text()
                     _LOGGER.error("Anthropic API error %d: %s", resp.status, error_text)
-                    raise Exception(f"Anthropic API error {resp.status}")
+                    # Surface the API's own error message (e.g. "prompt is too
+                    # long: N tokens > 200000 maximum") instead of a bare status
+                    # code so the user can see why the request failed (issue #80).
+                    try:
+                        detail = json.loads(error_text)["error"]["message"]
+                    except (ValueError, KeyError, TypeError):
+                        detail = error_text[:300]
+                    message = f"Anthropic API error {resp.status}: {detail}"
+                    if resp.status == 429:
+                        # Honor the server's retry-after hint so the retry
+                        # loop waits out per-minute token windows.
+                        retry_after = None
+                        try:
+                            header = resp.headers.get("retry-after")
+                            if header is not None:
+                                retry_after = float(header)
+                        except (TypeError, ValueError):
+                            retry_after = None
+                        raise RateLimitedAIError(message, retry_after=retry_after)
+                    if 400 <= resp.status < 500 and resp.status != 408:
+                        # Deterministic client error - retrying the identical
+                        # payload cannot succeed, so don't burn retries on it.
+                        raise NonRetryableAIError(message)
+                    raise Exception(message)
                 data = await resp.json()
                 # Extract text from Anthropic response
                 content_blocks = data.get("content", [])
@@ -1642,6 +1687,79 @@ class AiAgentHaAgent:
     def _set_cached_data(self, key: str, data: Any) -> None:
         """Store data in cache with timestamp."""
         self._cache[key] = (time.time(), data)
+
+    # Maximum size (in characters) of a single data message added to the
+    # conversation. Large installs can return megabytes of entity data, which
+    # blows past the model's context window (~200k tokens for Claude) and makes
+    # every request fail with a deterministic 400 (issue #80). 50k chars is
+    # roughly 13k tokens, which also keeps requests within entry-tier
+    # per-minute token rate limits (e.g. Anthropic tier 1: 30k input
+    # tokens/min) even with a data message persisting in the history window.
+    MAX_DATA_MESSAGE_CHARS = 50_000
+
+    # Maximum combined size (in characters) of the message window sent to the
+    # provider per request. Several capped data messages can still stack past
+    # context and per-minute token budgets (issue #80); the most recent
+    # messages are kept. ~100k chars is roughly 25k tokens.
+    MAX_WINDOW_CHARS = 100_000
+
+    def _format_data_message(self, data: Any) -> str:
+        """Serialize fetched HA data for the conversation, capping its size.
+
+        If the payload is too large, list items are dropped from the end and a
+        truncation notice is included so the model knows to request more
+        specific data instead of the full dump.
+        """
+        message = json.dumps({"data": data}, default=str)
+        if len(message) <= self.MAX_DATA_MESSAGE_CHARS:
+            return message
+
+        note = (
+            "Data truncated to fit the model context window. "
+            "Request more specific data (e.g. a specific entity, domain or area) "
+            "to see the rest."
+        )
+        if isinstance(data, list) and data:
+            truncated = data
+            while len(message) > self.MAX_DATA_MESSAGE_CHARS and len(truncated) > 1:
+                # Scale down proportionally to the overshoot, then re-check
+                # (item sizes vary, so loop until it actually fits).
+                keep = max(
+                    1,
+                    len(truncated) * self.MAX_DATA_MESSAGE_CHARS // len(message),
+                )
+                truncated = truncated[:keep]
+                message = json.dumps(
+                    {
+                        "data": truncated,
+                        "truncated": True,
+                        "total_items": len(data),
+                        "items_shown": len(truncated),
+                        "note": note,
+                    },
+                    default=str,
+                )
+            _LOGGER.warning(
+                "Data response truncated from %d to %d items to fit context window",
+                len(data),
+                len(truncated),
+            )
+            return message
+
+        # Non-list payloads: keep a prefix of the serialized form as a preview.
+        _LOGGER.warning(
+            "Oversized non-list data response truncated from %d chars", len(message)
+        )
+        preview = message[: self.MAX_DATA_MESSAGE_CHARS]
+        result = json.dumps({"data_preview": preview, "truncated": True, "note": note})
+        # JSON-escaping the preview can push the result back over the cap;
+        # shrink until the final message actually fits.
+        while len(result) > self.MAX_DATA_MESSAGE_CHARS and preview:
+            preview = preview[: int(len(preview) * 0.9)]
+            result = json.dumps(
+                {"data_preview": preview, "truncated": True, "note": note}
+            )
+        return result
 
     def _sanitize_automation_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
         """Sanitize automation configuration to prevent injection attacks."""
@@ -3129,11 +3247,19 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                 _LOGGER.debug("Adding system message to new conversation")
                 self.conversation_history.append(self.system_prompt)
 
+            # Remember where this query started so a failure can be rolled
+            # back instead of leaving dangling/oversized messages that poison
+            # every subsequent query (issue #80).
+            history_checkpoint = len(self.conversation_history)
+
             # Add user query to conversation
             self.conversation_history.append({"role": "user", "content": user_query})
             _LOGGER.debug("Added user query to conversation history")
 
-            max_iterations = 5  # Prevent infinite loops
+            # Prevent infinite loops while leaving room for multi-step
+            # discovery: with data responses capped (issue #80) the model may
+            # need several narrower data requests instead of one big dump.
+            max_iterations = 8
             iteration = 0
 
             while iteration < max_iterations:
@@ -3408,7 +3534,7 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                             self.conversation_history.append(
                                 {
                                     "role": "user",
-                                    "content": json.dumps({"data": data}, default=str),
+                                    "content": self._format_data_message(data),
                                 }
                             )
                             continue
@@ -3527,7 +3653,7 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                             self.conversation_history.append(
                                 {
                                     "role": "user",
-                                    "content": json.dumps({"data": data}, default=str),
+                                    "content": self._format_data_message(data),
                                 }
                             )
                             continue
@@ -3672,7 +3798,7 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                             self.conversation_history.append(
                                 {
                                     "role": "user",
-                                    "content": json.dumps({"data": data}, default=str),
+                                    "content": self._format_data_message(data),
                                 }
                             )
                             # Go to next iteration to continue the loop
@@ -3804,6 +3930,12 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                                 "request_type": "final_response",
                                 "response": response_to_wrap,
                             }
+                            # Keep the conversation paired: record the assistant
+                            # reply so history doesn't end with a dangling user
+                            # message (issue #80).
+                            self.conversation_history.append(
+                                {"role": "assistant", "content": response_to_wrap}
+                            )
                             result = {
                                 "success": True,
                                 "answer": json.dumps(wrapped_response),
@@ -3824,6 +3956,9 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
 
                 except Exception as e:
                     _LOGGER.exception("Error processing AI response: %s", str(e))
+                    # Roll back this query's messages so the failure doesn't
+                    # poison subsequent queries (issue #80).
+                    del self.conversation_history[history_checkpoint:]
                     return _with_debug(
                         {
                             "success": False,
@@ -3833,6 +3968,9 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
 
             # If we've reached max iterations without a final response
             _LOGGER.warning("Reached maximum iterations without final response")
+            # Roll back this query's messages so the failure doesn't poison
+            # subsequent queries (issue #80).
+            del self.conversation_history[history_checkpoint:]
             result = {
                 "success": False,
                 "error": "Maximum iterations reached without final response",
@@ -3870,15 +4008,27 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
             raise Exception("Rate limit exceeded. Please try again later.")
         retry_count = 0
         last_error = None
-        # Limit conversation history to last 10 messages to prevent token overflow
-        recent_messages = (
-            self.conversation_history[-10:]
-            if len(self.conversation_history) > 10
-            else self.conversation_history
-        )
-        # Ensure system prompt is always the first message
-        if not recent_messages or recent_messages[0].get("role") != "system":
-            recent_messages = [self.system_prompt] + recent_messages
+        # Limit conversation history to the last 10 messages to prevent token
+        # overflow, and cap the window's total size as well: even
+        # individually-capped data messages can stack up past context and
+        # per-minute token budgets (issue #80). Most recent messages win.
+        candidates = [
+            m for m in self.conversation_history[-10:] if m.get("role") != "system"
+        ]
+        recent_messages: List[Dict[str, Any]] = []
+        total_chars = 0
+        for message in reversed(candidates):
+            size = len(str(message.get("content") or ""))
+            if recent_messages and total_chars + size > self.MAX_WINDOW_CHARS:
+                break
+            recent_messages.insert(0, message)
+            total_chars += size
+        # Dropping/slicing can cut mid-turn; ensure the window starts with a
+        # user turn (issue #80).
+        while recent_messages and recent_messages[0].get("role") == "assistant":
+            recent_messages.pop(0)
+        # System prompt is always the first message
+        recent_messages = [self.system_prompt] + recent_messages
 
         _LOGGER.debug("Sending %d messages to AI provider", len(recent_messages))
         _LOGGER.debug("AI provider: %s", self.config.get("ai_provider", "unknown"))
@@ -3942,6 +4092,10 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                         continue
 
                 return str(response)
+            except NonRetryableAIError:
+                # Deterministic client error (e.g. 400 "prompt is too long") -
+                # retrying the same payload cannot succeed (issue #80).
+                raise
             except Exception as e:
                 _LOGGER.error(
                     "AI client error on attempt %d: %s", retry_count + 1, str(e)
@@ -3949,7 +4103,13 @@ Then restart Home Assistant to see your new dashboard in the sidebar."""
                 last_error = e
                 retry_count += 1
                 if retry_count < self._max_retries:
-                    await asyncio.sleep(self._retry_delay * retry_count)
+                    delay: float = self._retry_delay * retry_count
+                    if isinstance(e, RateLimitedAIError) and e.retry_after:
+                        # Wait at least as long as the provider asked for
+                        # (capped at 60s) so per-minute token windows can
+                        # actually reset (issue #80).
+                        delay = max(delay, min(e.retry_after, 60))
+                    await asyncio.sleep(delay)
                 continue
         raise Exception(
             f"Failed after {retry_count} retries. Last error: {str(last_error)}"

--- a/custom_components/ai_agent_ha/manifest.json
+++ b/custom_components/ai_agent_ha/manifest.json
@@ -20,5 +20,5 @@
     "requirements": [
         "aiohttp>=3.8.0"
     ],
-    "version": "1.13"
+    "version": "1.14"
 }

--- a/tests/test_ai_agent_ha/test_issue_80.py
+++ b/tests/test_ai_agent_ha/test_issue_80.py
@@ -1,0 +1,430 @@
+"""Regression tests for issue #80: Anthropic API error 400 on all queries.
+
+Covers the four fixes:
+  1. AnthropicClient surfaces the API error body and raises NonRetryableAIError
+     for deterministic 4xx errors (429/408 stay retryable).
+  2. _get_ai_response does not burn retries on non-retryable errors.
+  3. Oversized data responses are truncated before entering the conversation
+     so they cannot blow the model context window.
+  4. A failed query is rolled back from conversation history so it cannot
+     poison subsequent queries.
+"""
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add the parent directory to the path for direct imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def _mock_aiohttp_session(response_text, status=200, headers=None):
+    """Patch aiohttp.ClientSession to return a fixed HTTP body/status."""
+
+    class _FakeResp:
+        def __init__(self):
+            self.status = status
+            self.headers = headers or {}
+
+        async def text(self):
+            return response_text
+
+        async def json(self):
+            return json.loads(response_text)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class _FakeSession:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def post(self, *args, **kwargs):
+            return _FakeResp()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    return patch(
+        "custom_components.ai_agent_ha.agent.aiohttp.ClientSession", _FakeSession
+    )
+
+
+ERROR_400_BODY = json.dumps(
+    {
+        "type": "error",
+        "error": {
+            "type": "invalid_request_error",
+            "message": "prompt is too long: 205547 tokens > 200000 maximum",
+        },
+    }
+)
+
+
+def _make_agent():
+    from custom_components.ai_agent_ha.agent import AiAgentHaAgent
+
+    hass = MagicMock()
+    hass.data = {"ai_agent_ha": {"configs": {}}}
+    config = {
+        "ai_provider": "anthropic",
+        "anthropic_token": "sk-ant-" + "x" * 40,
+        "models": {"anthropic": "claude-sonnet-4-5-20250929"},
+    }
+    agent = AiAgentHaAgent(hass, config)
+    agent._retry_delay = 0  # keep tests fast
+    return agent
+
+
+class TestAnthropicErrorSurfacing:
+    """Fix 1: error body surfaced, 4xx non-retryable."""
+
+    @pytest.mark.asyncio
+    async def test_400_raises_non_retryable_with_body(self):
+        try:
+            from custom_components.ai_agent_ha.agent import (
+                AnthropicClient,
+                NonRetryableAIError,
+            )
+        except ImportError:
+            pytest.skip("AnthropicClient not available")
+
+        client = AnthropicClient("sk-ant-" + "x" * 40)
+        with _mock_aiohttp_session(ERROR_400_BODY, status=400):
+            with pytest.raises(NonRetryableAIError) as exc_info:
+                await client.get_response([{"role": "user", "content": "hi"}])
+        assert "prompt is too long" in str(exc_info.value)
+        assert "400" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_429_stays_retryable_and_carries_retry_after(self):
+        try:
+            from custom_components.ai_agent_ha.agent import (
+                AnthropicClient,
+                NonRetryableAIError,
+                RateLimitedAIError,
+            )
+        except ImportError:
+            pytest.skip("AnthropicClient not available")
+
+        client = AnthropicClient("sk-ant-" + "x" * 40)
+        body = json.dumps(
+            {"type": "error", "error": {"type": "rate_limit_error", "message": "rl"}}
+        )
+        with _mock_aiohttp_session(body, status=429, headers={"retry-after": "23"}):
+            with pytest.raises(RateLimitedAIError) as exc_info:
+                await client.get_response([{"role": "user", "content": "hi"}])
+        assert not isinstance(exc_info.value, NonRetryableAIError)
+        assert exc_info.value.retry_after == 23.0
+
+    @pytest.mark.asyncio
+    async def test_retry_loop_waits_out_rate_limit_window(self):
+        try:
+            from custom_components.ai_agent_ha.agent import RateLimitedAIError
+        except ImportError:
+            pytest.skip("agent module not available")
+
+        agent = _make_agent()
+        sleeps = []
+        calls = {"n": 0}
+
+        class FakeClient:
+            async def get_response(self, messages, **kwargs):
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    raise RateLimitedAIError("429: rate limited", retry_after=17)
+                return json.dumps({"request_type": "final_response", "response": "ok"})
+
+        agent.ai_client = FakeClient()
+        agent.conversation_history = [
+            agent.system_prompt,
+            {"role": "user", "content": "hi"},
+        ]
+
+        import asyncio as _asyncio
+
+        real_sleep = _asyncio.sleep
+
+        async def fake_sleep(t):
+            sleeps.append(t)
+            await real_sleep(0)
+
+        with patch("custom_components.ai_agent_ha.agent.asyncio.sleep", fake_sleep):
+            response = await agent._get_ai_response()
+        assert json.loads(response)["response"] == "ok"
+        assert sleeps and sleeps[0] == 17, f"retry-after not honored: {sleeps}"
+
+    @pytest.mark.asyncio
+    async def test_500_stays_retryable(self):
+        try:
+            from custom_components.ai_agent_ha.agent import (
+                AnthropicClient,
+                NonRetryableAIError,
+            )
+        except ImportError:
+            pytest.skip("AnthropicClient not available")
+
+        client = AnthropicClient("sk-ant-" + "x" * 40)
+        with _mock_aiohttp_session("upstream blew up", status=500):
+            with pytest.raises(Exception) as exc_info:
+                await client.get_response([{"role": "user", "content": "hi"}])
+        assert not isinstance(exc_info.value, NonRetryableAIError)
+        assert "upstream blew up" in str(exc_info.value)
+
+
+class TestNoRetryOnNonRetryable:
+    """Fix 2: _get_ai_response fails fast instead of 10 retries."""
+
+    @pytest.mark.asyncio
+    async def test_get_ai_response_does_not_retry(self):
+        try:
+            from custom_components.ai_agent_ha.agent import NonRetryableAIError
+        except ImportError:
+            pytest.skip("agent module not available")
+
+        agent = _make_agent()
+        calls = {"n": 0}
+
+        class FakeClient:
+            async def get_response(self, messages, **kwargs):
+                calls["n"] += 1
+                raise NonRetryableAIError("Anthropic API error 400: prompt is too long")
+
+        agent.ai_client = FakeClient()
+        agent.conversation_history = [
+            agent.system_prompt,
+            {"role": "user", "content": "hi"},
+        ]
+        with pytest.raises(NonRetryableAIError):
+            await agent._get_ai_response()
+        assert calls["n"] == 1, "non-retryable error must not be retried"
+
+    @pytest.mark.asyncio
+    async def test_retryable_errors_still_retried(self):
+        try:
+            from custom_components.ai_agent_ha.agent import AiAgentHaAgent  # noqa: F401
+        except ImportError:
+            pytest.skip("agent module not available")
+
+        agent = _make_agent()
+        calls = {"n": 0}
+
+        class FakeClient:
+            async def get_response(self, messages, **kwargs):
+                calls["n"] += 1
+                raise Exception("Anthropic API error 500: transient")
+
+        agent.ai_client = FakeClient()
+        agent.conversation_history = [
+            agent.system_prompt,
+            {"role": "user", "content": "hi"},
+        ]
+        with pytest.raises(Exception, match="Failed after"):
+            await agent._get_ai_response()
+        assert calls["n"] == agent._max_retries
+
+
+class TestDataMessageTruncation:
+    """Fix 3: oversized data responses are capped."""
+
+    def test_small_data_passthrough(self):
+        try:
+            from custom_components.ai_agent_ha.agent import AiAgentHaAgent  # noqa: F401
+        except ImportError:
+            pytest.skip("agent module not available")
+
+        agent = _make_agent()
+        data = [{"entity_id": "sensor.a", "state": "1"}]
+        msg = agent._format_data_message(data)
+        assert json.loads(msg) == {"data": data}
+
+    def test_large_list_truncated_under_cap(self):
+        try:
+            from custom_components.ai_agent_ha.agent import AiAgentHaAgent  # noqa: F401
+        except ImportError:
+            pytest.skip("agent module not available")
+
+        agent = _make_agent()
+        # ~2600 entities x ~400 chars each, like the live repro of issue #80
+        data = [
+            {
+                "entity_id": f"sensor.device_{i}_power",
+                "state": "42.0",
+                "attributes": {"friendly_name": f"Device {i} Power", "x": "y" * 300},
+            }
+            for i in range(2600)
+        ]
+        raw_len = len(json.dumps({"data": data}))
+        assert raw_len > agent.MAX_DATA_MESSAGE_CHARS  # sanity: input is oversized
+
+        msg = agent._format_data_message(data)
+        assert len(msg) <= agent.MAX_DATA_MESSAGE_CHARS
+        parsed = json.loads(msg)
+        assert parsed["truncated"] is True
+        assert parsed["total_items"] == 2600
+        assert parsed["items_shown"] == len(parsed["data"])
+        assert 0 < parsed["items_shown"] < 2600
+        # order preserved: first items survive
+        assert parsed["data"][0]["entity_id"] == "sensor.device_0_power"
+        assert "note" in parsed
+
+    def test_large_dict_truncated_under_cap(self):
+        try:
+            from custom_components.ai_agent_ha.agent import AiAgentHaAgent  # noqa: F401
+        except ImportError:
+            pytest.skip("agent module not available")
+
+        agent = _make_agent()
+        data = {f"area_{i}": {"name": "x" * 500} for i in range(1000)}
+        msg = agent._format_data_message(data)
+        assert len(msg) <= agent.MAX_DATA_MESSAGE_CHARS
+        parsed = json.loads(msg)
+        assert parsed["truncated"] is True
+
+
+class TestHistoryRollbackOnFailure:
+    """Fix 4: failed queries don't poison the conversation history."""
+
+    @pytest.mark.asyncio
+    async def test_failed_query_rolled_back_and_next_query_succeeds(self):
+        try:
+            from custom_components.ai_agent_ha.agent import (
+                AnthropicClient,
+                NonRetryableAIError,
+            )
+        except ImportError:
+            pytest.skip("agent module not available")
+
+        agent = _make_agent()
+        behavior = {"fail": True}
+
+        async def fake_get_response(self, messages, **kwargs):
+            if behavior["fail"]:
+                raise NonRetryableAIError("Anthropic API error 400: prompt is too long")
+            return json.dumps(
+                {"request_type": "final_response", "response": "All good"}
+            )
+
+        with patch.object(AnthropicClient, "get_response", fake_get_response):
+            result1 = await agent.process_query("query that fails")
+            assert result1["success"] is False
+            assert "prompt is too long" in result1["error"]
+            # rollback: only the system prompt remains
+            roles = [m["role"] for m in agent.conversation_history]
+            assert roles == ["system"], f"history not rolled back: {roles}"
+
+            behavior["fail"] = False
+            result2 = await agent.process_query("query that succeeds")
+            assert result2["success"] is True
+            assert result2["answer"] == "All good"
+
+
+class TestWindowAlignment:
+    """History window never starts with an assistant message after slicing."""
+
+    @pytest.mark.asyncio
+    async def test_window_starts_with_user_turn(self):
+        try:
+            from custom_components.ai_agent_ha.agent import AiAgentHaAgent  # noqa: F401
+        except ImportError:
+            pytest.skip("agent module not available")
+
+        agent = _make_agent()
+        captured = {}
+
+        class FakeClient:
+            async def get_response(self, messages, **kwargs):
+                captured["messages"] = messages
+                return json.dumps({"request_type": "final_response", "response": "ok"})
+
+        agent.ai_client = FakeClient()
+        # 12 messages so [-10:] slices mid-turn and would start with assistant
+        history = [agent.system_prompt]
+        for i in range(5):
+            history.append({"role": "user", "content": f"u{i}"})
+            history.append({"role": "assistant", "content": f"a{i}"})
+        history.append({"role": "user", "content": "final"})
+        agent.conversation_history = history
+        assert history[-10:][0]["role"] == "assistant"  # sanity: slice is misaligned
+
+        await agent._get_ai_response()
+        sent = captured["messages"]
+        assert sent[0]["role"] == "system"
+        assert (
+            sent[1]["role"] == "user"
+        ), f"window starts mid-turn: {[m['role'] for m in sent]}"
+
+    @pytest.mark.asyncio
+    async def test_window_total_size_capped(self):
+        try:
+            from custom_components.ai_agent_ha.agent import AiAgentHaAgent  # noqa: F401
+        except ImportError:
+            pytest.skip("agent module not available")
+
+        agent = _make_agent()
+        captured = {}
+
+        class FakeClient:
+            async def get_response(self, messages, **kwargs):
+                captured["messages"] = messages
+                return json.dumps({"request_type": "final_response", "response": "ok"})
+
+        agent.ai_client = FakeClient()
+        # several at-cap data messages stack past the window budget
+        history = [agent.system_prompt]
+        for i in range(4):
+            history.append({"role": "assistant", "content": f"req{i}"})
+            history.append(
+                {"role": "user", "content": json.dumps({"data": "x" * 49_000, "i": i})}
+            )
+        agent.conversation_history = history
+
+        await agent._get_ai_response()
+        sent = captured["messages"]
+        non_system_chars = sum(len(m["content"]) for m in sent if m["role"] != "system")
+        assert non_system_chars <= agent.MAX_WINDOW_CHARS
+        # the most recent data message must survive
+        assert any('"i": 3' in m["content"] for m in sent)
+
+
+class TestMaxIterationsRollback:
+    """Max-iterations failure also rolls history back."""
+
+    @pytest.mark.asyncio
+    async def test_max_iterations_rolls_back_history(self):
+        try:
+            from custom_components.ai_agent_ha.agent import AnthropicClient
+        except ImportError:
+            pytest.skip("agent module not available")
+
+        agent = _make_agent()
+
+        async def always_data_request(self, messages, **kwargs):
+            # model never produces a final answer
+            return json.dumps(
+                {
+                    "request_type": "data_request",
+                    "request": "get_automations",
+                    "parameters": {},
+                }
+            )
+
+        async def fake_get_automations():
+            return [{"id": "a1", "alias": "Test"}]
+
+        agent.get_automations = fake_get_automations
+        with patch.object(AnthropicClient, "get_response", always_data_request):
+            result = await agent.process_query("never finishes")
+        assert result["success"] is False
+        assert "Maximum iterations" in result["error"]
+        roles = [m["role"] for m in agent.conversation_history]
+        assert roles == ["system"], f"history not rolled back: {roles}"

--- a/tests/test_ai_agent_ha/test_issue_80.py
+++ b/tests/test_ai_agent_ha/test_issue_80.py
@@ -290,6 +290,23 @@ class TestDataMessageTruncation:
         parsed = json.loads(msg)
         assert parsed["truncated"] is True
 
+    def test_single_oversized_list_item_still_capped(self):
+        try:
+            from custom_components.ai_agent_ha.agent import (  # noqa: F401
+                AiAgentHaAgent,
+            )
+        except ImportError:
+            pytest.skip("agent module not available")
+
+        agent = _make_agent()
+        # one list item alone exceeds the cap - the item-dropping loop can't
+        # shrink below one item, so the hard-truncated preview must kick in
+        data = [{"entity_id": "sensor.giant", "attributes": {"blob": "x" * 200_000}}]
+        msg = agent._format_data_message(data)
+        assert len(msg) <= agent.MAX_DATA_MESSAGE_CHARS
+        parsed = json.loads(msg)
+        assert parsed["truncated"] is True
+
 
 class TestHistoryRollbackOnFailure:
     """Fix 4: failed queries don't poison the conversation history."""


### PR DESCRIPTION
Fixes #80

## Root cause (confirmed live against the real Anthropic API)

The reported `Error processing AI response: Failed after 10 retries. Last error: Anthropic API error 400` is **not** caused by Claude refusing JSON-only output (probed live: Claude returns valid JSON for our system prompt, and consecutive stacked `user` messages get HTTP 200 — the API merges them). The actual chain:

1. For a query like *"What is the current solar export and is the heat pump running?"*, Claude requests discovery data (`get_entity_registry` / `get_entities_by_domain`)
2. The integration dumps the **entire install** into one conversation message — 848KB on a ~2,600-entity setup
3. Real API response: `400 prompt is too long: 205547 tokens > 200000 maximum` (`req_011CbnaWbA8qNAqPu73KN6Xf`)
4. The error body was discarded (`agent.py` raised only the status code), so users saw an opaque `400`
5. The identical doomed payload was retried 10× (+45s of backoff)
6. The oversized message **persisted in conversation history**, so every subsequent query failed too → "all queries fail"

## Fixes

- **Cap data responses** (~50k chars ≈ 13k tokens) with a truncation notice telling the model to request narrower data
- **Cap the per-request message window** (~100k chars) so capped data messages can't stack past context/rate-limit budgets
- **Surface provider error bodies** in the UI error instead of a bare status code
- **`NonRetryableAIError`**: deterministic 4xx fails fast instead of 10 futile retries
- **`RateLimitedAIError` + `retry-after`**: 429s wait out per-minute token windows (e.g. tier 1: 30k input tokens/min) instead of burning retries in seconds
- **History rollback on failure** so failed queries can't poison subsequent ones
- **Window alignment**: the 10-message slice can no longer start mid-turn
- **Timeout 30s → 300s** for Anthropic, matching every other provider client
- **`max_iterations` 5 → 8** since capped data can require extra narrower requests

## Verification

- Reproduced the issue byte-for-byte against the **real** Anthropic API with the reporter's exact model (`claude-sonnet-4-5-20250929`) before the fix
- After the fix, the same live end-to-end run succeeds: Claude reads the truncated registry, queries the two specific entities, recovers from a real tier-1 429 via `retry-after`, and returns the expected natural-language answer (`success: true`)
- 13 new regression tests in `tests/test_ai_agent_ha/test_issue_80.py`; `black`/`isort`/`flake8`/`mypy` clean

Bumps version to 1.14 with changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)