### PR TITLE
chore: clean release notes + ignore local venv/repro artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,9 @@ jobs:
     - name: Create Release
       uses: softprops/action-gh-release@v2
       with:
-        tag_name: ${{ github.ref }}
-        name: Release ${{ github.ref }}
-        body: |
-          Changes in this Release
-          - Automated release for tag ${{ github.ref }}
+        tag_name: ${{ github.ref_name }}
+        name: ${{ github.ref_name }}
+        generate_release_notes: true
         draft: false
         prerelease: false
         files: ai_agent_ha.zip

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/
 build/
 *.egg
 .venv/
+.venv-repro/
 venv/
 env/
 
@@ -38,4 +39,9 @@ htmlcov/
 # Home Assistant (if used)
 home-assistant.log
 homeassistant/
-.gitignore
+
+# Local issue-repro / e2e scratch scripts (not part of the test suite)
+repro_issue_*.py
+live_repro_issue_*.py
+run_tests_issue_*.py
+e2e_issue_*.py


### PR DESCRIPTION
Follow-up housekeeping after the #82 / #83 release.

## `release.yml`
The release step used `${{ github.ref }}` for the release **name** and **body**, so the published GitHub Release rendered the raw ref — e.g. the v1.14.1 release came out titled `Release refs/tags/v1.14.1` with a body of `Automated release for tag refs/tags/v1.14.1` (I fixed that one by hand).

- `name` / `tag_name` → `${{ github.ref_name }}` (clean `v1.14.1`).
- Dropped the static body in favor of `generate_release_notes: true`, so future releases get an automatic changelog from merged PRs.

## `.gitignore`
- Ignore `.venv-repro/` — the local Home Assistant test venv.
- Ignore `*_issue_*.py` repro/e2e scratch scripts so they can't be committed by accident.

No functional/integration code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)